### PR TITLE
rqt_image_view: Adding the possibility to publish mouse events.

### DIFF
--- a/rqt_image_view/CMakeLists.txt
+++ b/rqt_image_view/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(rqt_image_view)
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS rqt_gui rqt_gui_cpp image_transport sensor_msgs cv_bridge)
+find_package(catkin REQUIRED COMPONENTS rqt_gui rqt_gui_cpp image_transport sensor_msgs geometry_msgs cv_bridge)
 
 find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
 
@@ -30,7 +30,7 @@ set(rqt_image_view_INCLUDE_DIRECTORIES
 catkin_package(
 	INCLUDE_DIRS ${rqt_image_view_INCLUDE_DIRECTORIES}
 	LIBRARIES ${PROJECT_NAME} 
-	CATKIN_DEPENDS rqt_gui rqt_gui_cpp image_transport sensor_msgs cv_bridge
+	CATKIN_DEPENDS rqt_gui rqt_gui_cpp image_transport sensor_msgs geometry_msgs cv_bridge
 )
 catkin_python_setup()
 

--- a/rqt_image_view/include/rqt_image_view/image_view.h
+++ b/rqt_image_view/include/rqt_image_view/image_view.h
@@ -113,9 +113,9 @@ protected:
 
   cv::Mat conversion_mat_;
 
-  ros::Publisher pubMouseLeft;
+  ros::Publisher pub_mouse_left_;
 
-  bool pubTopicCustom;
+  bool pub_topic_custom_;
 
 };
 

--- a/rqt_image_view/include/rqt_image_view/image_view.h
+++ b/rqt_image_view/include/rqt_image_view/image_view.h
@@ -39,6 +39,7 @@
 
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/Image.h>
+#include <geometry_msgs/Point.h>
 
 #include <opencv2/core/core.hpp>
 
@@ -91,6 +92,12 @@ protected slots:
 
   virtual void onDynamicRange(bool checked);
 
+  virtual void onMousePublish(bool checked);
+
+  virtual void onMouseLeft(int x, int y);
+
+  virtual void onPubTopicChanged();
+
 protected:
 
   virtual void callbackImage(const sensor_msgs::Image::ConstPtr& msg);
@@ -105,6 +112,10 @@ protected:
   QMutex qimage_mutex_;
 
   cv::Mat conversion_mat_;
+
+  ros::Publisher pubMouseLeft;
+
+  bool pubTopicCustom;
 
 };
 

--- a/rqt_image_view/include/rqt_image_view/ratio_layouted_frame.h
+++ b/rqt_image_view/include/rqt_image_view/ratio_layouted_frame.h
@@ -76,6 +76,12 @@ private:
 
   QSize aspect_ratio_;
 
+  void mousePressEvent(QMouseEvent * mouseEvent);
+
+signals:
+
+  void mouseLeft(int x, int y);
+
 };
 
 }

--- a/rqt_image_view/package.xml
+++ b/rqt_image_view/package.xml
@@ -20,11 +20,13 @@
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>rqt_gui</run_depend>
   <run_depend>rqt_gui_cpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/rqt_image_view/package.xml
+++ b/rqt_image_view/package.xml
@@ -16,17 +16,17 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cv_bridge</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
   <run_depend>cv_bridge</run_depend>
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>rqt_gui</run_depend>
   <run_depend>rqt_gui_cpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/rqt_image_view/src/rqt_image_view/image_view.cpp
+++ b/rqt_image_view/src/rqt_image_view/image_view.cpp
@@ -75,6 +75,13 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext& context)
   connect(ui_.zoom_1_push_button, SIGNAL(toggled(bool)), this, SLOT(onZoom1(bool)));
   
   connect(ui_.dynamic_range_check_box, SIGNAL(toggled(bool)), this, SLOT(onDynamicRange(bool)));
+
+  pubTopicCustom = false;
+  QRegExp rx("([a-zA-Z/][a-zA-Z0-9_/]*)?"); //see http://www.ros.org/wiki/ROS/Concepts#Names.Valid_Names (but also accept an empty field)
+  ui_.publish_click_location_topic_line_edit->setValidator(new QRegExpValidator(rx, this));
+  connect(ui_.publish_click_location_check_box, SIGNAL(toggled(bool)), this, SLOT(onMousePublish(bool)));
+  connect(ui_.image_frame, SIGNAL(mouseLeft(int, int)), this, SLOT(onMouseLeft(int, int)));
+  connect(ui_.publish_click_location_topic_line_edit, SIGNAL(editingFinished()), this, SLOT(onPubTopicChanged()));
 }
 
 bool ImageView::eventFilter(QObject* watched, QEvent* event)
@@ -108,6 +115,7 @@ bool ImageView::eventFilter(QObject* watched, QEvent* event)
 void ImageView::shutdownPlugin()
 {
   subscriber_.shutdown();
+  pubMouseLeft.shutdown();
 }
 
 void ImageView::saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::Settings& instance_settings) const
@@ -247,6 +255,9 @@ void ImageView::onTopicChanged(int index)
       QMessageBox::warning(widget_, tr("Loading image transport plugin failed"), e.what());
     }
   }
+
+  pubMouseLeft.shutdown();
+  onMousePublish(ui_.publish_click_location_check_box->isChecked());
 }
 
 void ImageView::onZoom1(bool checked)
@@ -272,6 +283,51 @@ void ImageView::onZoom1(bool checked)
 void ImageView::onDynamicRange(bool checked)
 {
   ui_.max_range_double_spin_box->setEnabled(!checked);
+}
+
+void ImageView::onMousePublish(bool checked)
+{
+    if(checked)
+    {
+        std::string topicName;
+        if(pubTopicCustom)
+            topicName = ui_.publish_click_location_topic_line_edit->text().toStdString();
+        else
+        {
+            if(!subscriber_.getTopic().empty())
+                topicName = subscriber_.getTopic()+"_mouse_left";
+            else
+                topicName = "mouse_left";
+            ui_.publish_click_location_topic_line_edit->setText(QString::fromStdString(topicName));
+        }
+        pubMouseLeft = getNodeHandle().advertise<geometry_msgs::Point>(topicName, 1000);
+    }
+    else
+        pubMouseLeft.shutdown();
+}
+
+void ImageView::onMouseLeft(int x, int y)
+{
+    if(ui_.publish_click_location_check_box->isChecked())
+    {
+        geometry_msgs::Point clickLocation;
+        // Publish click location in normalized image coordinates
+        clickLocation.x = (double)x/(double)ui_.image_frame->width();
+        clickLocation.y = (double)y/(double)ui_.image_frame->height();;
+        clickLocation.z = 0;
+        pubMouseLeft.publish(clickLocation);
+    }
+}
+
+void ImageView::onPubTopicChanged()
+{
+    if(ui_.publish_click_location_topic_line_edit->text().isEmpty())
+        pubTopicCustom = false;
+    else
+        pubTopicCustom = true;
+
+    pubMouseLeft.shutdown();
+    onMousePublish(ui_.publish_click_location_check_box->isChecked());
 }
 
 void ImageView::callbackImage(const sensor_msgs::Image::ConstPtr& msg)

--- a/rqt_image_view/src/rqt_image_view/image_view.cpp
+++ b/rqt_image_view/src/rqt_image_view/image_view.cpp
@@ -310,12 +310,12 @@ void ImageView::onMousePublish(bool checked)
 
 void ImageView::onMouseLeft(int x, int y)
 {
-  if(ui_.publish_click_location_check_box->isChecked())
+  if(ui_.publish_click_location_check_box->isChecked() && !qimage_.isNull())
   {
     geometry_msgs::Point clickLocation;
-    // Publish click location in normalized image coordinates
-    clickLocation.x = (double)x/(double)ui_.image_frame->width();
-    clickLocation.y = (double)y/(double)ui_.image_frame->height();;
+    // Publish click location in pixel coordinates
+    clickLocation.x = round((double)x/(double)ui_.image_frame->width()*(double)qimage_.width());
+    clickLocation.y = round((double)y/(double)ui_.image_frame->height()*(double)qimage_.height());
     clickLocation.z = 0;
     pub_mouse_left_.publish(clickLocation);
   }

--- a/rqt_image_view/src/rqt_image_view/image_view.ui
+++ b/rqt_image_view/src/rqt_image_view/image_view.ui
@@ -16,7 +16,7 @@
   <property name="windowTitle">
    <string>Image View</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,0">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,1">
      <item>
@@ -70,6 +70,46 @@
      </item>
      <item>
       <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QCheckBox" name="publish_click_location_check_box">
+       <property name="toolTip">
+        <string>Publish click location</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="publish_click_location_topic_line_edit">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>Click location topic (leave empty for auto-naming)</string>
+       </property>
+       <property name="autoFillBackground">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>

--- a/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
+++ b/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
@@ -116,7 +116,9 @@ int RatioLayoutedFrame::greatestCommonDivisor(int a, int b)
 
 void RatioLayoutedFrame::mousePressEvent(QMouseEvent * mouseEvent)
 {
-    if(mouseEvent->button() == Qt::LeftButton)
-        emit mouseLeft(mouseEvent->x(), mouseEvent->y());
+  if(mouseEvent->button() == Qt::LeftButton)
+  {
+    emit mouseLeft(mouseEvent->x(), mouseEvent->y());
+  }
 }
 }

--- a/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
+++ b/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
@@ -33,6 +33,7 @@
 #include <rqt_image_view/ratio_layouted_frame.h>
 
 #include <assert.h>
+#include <QMouseEvent>
 
 namespace rqt_image_view {
 
@@ -113,4 +114,9 @@ int RatioLayoutedFrame::greatestCommonDivisor(int a, int b)
   return greatestCommonDivisor(b, a % b);
 }
 
+void RatioLayoutedFrame::mousePressEvent(QMouseEvent * mouseEvent)
+{
+    if(mouseEvent->button() == Qt::LeftButton)
+        emit mouseLeft(mouseEvent->x(), mouseEvent->y());
+}
 }

--- a/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
+++ b/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
@@ -120,5 +120,6 @@ void RatioLayoutedFrame::mousePressEvent(QMouseEvent * mouseEvent)
   {
     emit mouseLeft(mouseEvent->x(), mouseEvent->y());
   }
+  QFrame::mousePressEvent(mouseEvent);
 }
 }


### PR DESCRIPTION
Allow for some interactivity by capturing and publishing mouse clicks on the displayed image. I didn't see any possibility to do that from within rqt right now except for a rather complicated approach [recently discussed in ROS answers](http://answers.ros.org/question/56185/creating-interactive-image-displayin-rviz/).

The mouse click location is published as [geometry_msgs/Point](http://ros.org/doc/api/geometry_msgs/html/msg/Point.html) with [0,0,0] representing the top left corner and [1,1,0] representing the bottom right corner.

The topic name is chosen automatically based on the subscribed image topic by default but it is possible to choose your own.

This is only a small extension so I didn't consider putting it into a separate plugin. That might be a good idea though, if this added functionality might cause confusion.