### PR TITLE
rqt_reconfigure) fix division by zero

### DIFF
--- a/rqt_reconfigure/src/rqt_reconfigure/param_editors.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/param_editors.py
@@ -220,6 +220,9 @@ class DoubleEditor(EditorWidget):
             self.ifunc = lambda x: math.tan(x)
 
         self.scale = (self.func(self.max) - self.func(self.min)) / 100
+        if self.scale == 0:
+            self.setDisabled(True)
+
         self.offset = self.func(self.min)
 
         self._slider_horizontal.setRange(self.slider_value(self.min),
@@ -240,7 +243,7 @@ class DoubleEditor(EditorWidget):
         return self.ifunc(self._slider_horizontal.value() * self.scale)
 
     def slider_value(self, value):
-        return int(round((self.func(value)) / self.scale))
+        return int(round((self.func(value)) / self.scale)) if self.scale else 0
 
     def slider_released(self):
         self.update_text(self.get_value())


### PR DESCRIPTION
This change fixes https://github.com/ros-visualization/rqt_common_plugins/issues/59 and also disables the widgets for fixed parameters, to make them stand out visually.
