### PR TITLE
fixed an unexpected type error for enum parameters; fixed calling update_value() twice

### DIFF
--- a/rqt_reconfigure/src/rqt_reconfigure/param_editors.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/param_editors.py
@@ -285,8 +285,14 @@ class EnumEditor(EditorWidget):
         self._combobox.currentIndexChanged['int'].connect(self.selected)
 
     def selected(self, index):
-        self._combobox.setCurrentIndex(self.values[index])
         self._update(self.values[index])
 
-    #def update_value(self, val):
-    #    self._combobox.setCurrentIndex(self.values.index(val))
+    def update_value(self, val):
+        # apparently, when the currentIndexChanged signal is emitted, current 
+        # index internally is still the old value, why the setCurrentIndex call
+        # below triggers another selected() call ... couldn't fin a better 
+        # solution than this. 
+        self._combobox.currentIndexChanged['int'].disconnect()
+        self._combobox.setCurrentIndex(self.values.index(val))
+        self._combobox.currentIndexChanged['int'].connect(self.selected)
+


### PR DESCRIPTION
sorry for not checking the problem with the last pull request earlier, things have been a bit busy ...  
apparently, when the currentIndexChanged signal is emitted, current index internally is still the old value, why the setCurrentIndex() call in update_value() triggers another selected() call ... couldn't fin a better solution than quickly disconnecting / connecting. 
If that doesn't suit, I'd ask to remove at least line 288. This gives the user the impression that he is able to change the parameter, but under the hood, nothing is happening silently 
