### PR TITLE
fixes #124: removed vertical header

### DIFF
--- a/rqt_console/src/rqt_console/console_widget.py
+++ b/rqt_console/src/rqt_console/console_widget.py
@@ -92,6 +92,7 @@ class ConsoleWidget(QWidget):
         for idx, width in enumerate(self._columnwidth):
             self.table_view.horizontalHeader().resizeSection(idx, width)
         self.table_view.sortByColumn(3, Qt.DescendingOrder)
+        self.table_view.verticalHeader().setVisible(False)
 
         self.add_exclude_button.setIcon(QIcon.fromTheme('list-add'))
         self.add_highlight_button.setIcon(QIcon.fromTheme('list-add'))


### PR DESCRIPTION
The numbers were meant to be a feature but since they are not actually a unique identifier they have become anything but. I am removing them to save space and get rid of other minor issues.
