### PR TITLE
fixes #133: check message limit on change

### DIFF
--- a/rqt_console/src/rqt_console/console.py
+++ b/rqt_console/src/rqt_console/console.py
@@ -102,4 +102,4 @@ class Console(Plugin):
     def trigger_configuration(self):
         self._consolesubscriber.set_message_limit(self._datamodel._message_limit)
         if self._consolesubscriber.show_dialog():
-            self._datamodel._message_limit = self._consolesubscriber.get_message_limit()
+            self._datamodel.set_message_limit(self._consolesubscriber.get_message_limit())

--- a/rqt_console/src/rqt_console/message_data_model.py
+++ b/rqt_console/src/rqt_console/message_data_model.py
@@ -91,6 +91,16 @@ class MessageDataModel(QAbstractTableModel):
                 return '#%d' % (section + 1)
     # END Required implementations of QAbstractTableModel functions
 
+    def set_message_limit(self, new_limit):
+        self._message_limit = new_limit
+        self.manage_message_limit()
+
+    def manage_message_limit(self):
+        if len(self.get_message_list()) > self._message_limit:
+            self.beginRemoveRows(QModelIndex(), 0, len(self.get_message_list()) - self._message_limit - 1)
+            del self.get_message_list()[0:len(self.get_message_list()) - self._message_limit]
+            self.endRemoveRows()
+
     def insert_rows(self, msgs):
         """
         Wraps the insert_row function to minimize gui notification calls
@@ -101,11 +111,7 @@ class MessageDataModel(QAbstractTableModel):
         for msg in msgs:
             self.insert_row(msg, False)
         self.endInsertRows()
-
-        if len(self.get_message_list()) > self._message_limit:
-            self.beginRemoveRows(QModelIndex(), 0, len(self.get_message_list()) - self._message_limit - 1)
-            del self.get_message_list()[0:len(self.get_message_list()) - self._message_limit]
-            self.endRemoveRows()
+        self.manage_message_limit()
 
     def insert_row(self, msg, notify_model=True):
         if notify_model:


### PR DESCRIPTION
now respects the new message limit on a change instead of waiting to update when the next message arrives.
