### PR TITLE
fixes #110: no waiting on unpublished topics

### DIFF
--- a/rqt_plot/src/rqt_plot/plot_widget.py
+++ b/rqt_plot/src/rqt_plot/plot_widget.py
@@ -191,10 +191,14 @@ class PlotWidget(QWidget):
             return
 
         self._rosdata[topic_name] = ROSData(topic_name, self._start_time)
-        data_x, data_y = self._rosdata[topic_name].next()
-        self.data_plot.add_curve(topic_name, topic_name, data_x, data_y)
+        if self._rosdata[topic_name].error is not None:
+            qWarning(str(self._rosdata[topic_name].error))
+            del self._rosdata[topic_name]
+        else:
+            data_x, data_y = self._rosdata[topic_name].next()
+            self.data_plot.add_curve(topic_name, topic_name, data_x, data_y)
 
-        self._subscribed_topics_changed()
+            self._subscribed_topics_changed()
 
     def remove_topic(self, topic_name):
         self._rosdata[topic_name].close()


### PR DESCRIPTION
I discussed this with a few people here and the consensus was that waiting at all was unreasonable. A simple warning is sufficient to notify the user what has transpired. If they wish to add it again after it is published that is possible. In the future it would be nice to have the concept of topics which are available in plot but "off" and thus not plotting at the moment.
