### PR TITLE
add a one-second timer that automatically updates the ros_graph view

### DIFF
--- a/rqt_graph/src/rqt_graph/ros_graph.py
+++ b/rqt_graph/src/rqt_graph/ros_graph.py
@@ -33,7 +33,7 @@ import os
 import rospkg
 
 from python_qt_binding import loadUi
-from python_qt_binding.QtCore import QAbstractListModel, QFile, QIODevice, Qt, Signal
+from python_qt_binding.QtCore import QAbstractListModel, QFile, QIODevice, Qt, Signal, QTimer
 from python_qt_binding.QtGui import QCompleter, QFileDialog, QGraphicsScene, QIcon, QImage, QPainter, QWidget
 from python_qt_binding.QtSvg import QSvgGenerator
 
@@ -174,6 +174,9 @@ class RosGraph(Plugin):
         self._deferred_fit_in_view.emit()
 
         context.add_widget(self._widget)
+        self._auto_refresh_timer = QTimer(self)
+        self._auto_refresh_timer.timeout.connect(self._update_rosgraph)
+        self._auto_refresh_timer.start(1000)
 
     def save_settings(self, plugin_settings, instance_settings):
         instance_settings.set_value('graph_type_combo_box_index', self._widget.graph_type_combo_box.currentIndex())


### PR DESCRIPTION
hello,

this is a quick-and-dirty tweak to ros_graph to make it automatically poll the graph every second, so that (for example, when demo'ing stuff), the window automatically updates to reflect what is happening. I think this is what rx_graph used to do. Anyway, my implementation is not the best, but it appears to work.
