### PR TITLE
rqt_graph: changed the method of zooming

### DIFF
--- a/rqt_graph/src/rqt_graph/interactive_graphics_view.py
+++ b/rqt_graph/src/rqt_graph/interactive_graphics_view.py
@@ -63,13 +63,11 @@ class InteractiveGraphicsView(QGraphicsView):
 
     def wheelEvent(self, wheel_event):
         if wheel_event.modifiers() == Qt.NoModifier:
-            num_degrees = wheel_event.delta() / 8.0
-            num_steps = num_degrees / 15.0
+            delta = wheel_event.delta()
+            delta = max(min(delta, 480), -480)
             mouse_before_scale_in_scene = self.mapToScene(wheel_event.pos())
 
-            scale_factor = 1.2 * num_steps
-            if num_steps < 0:
-                scale_factor = -1.0 / scale_factor
+            scale_factor = 1 + (0.2 * (delta / 120.0))
             scaling = QTransform(scale_factor, 0, 0, scale_factor, 0, 0)
             self.setTransform(self.transform() * scaling)
 


### PR DESCRIPTION
This new method handles smaller step sizes. The trackpad on Macbook Pros have a step size which ranges from +/-2 up to +/-1200, but with a normal mouse, in OS X or Linux, the step size is always +/-120 or +/-240. This new method scales better with smaller step sizes, making scrolling smoother when using a track pad, which was pretty much useless before.
