### PR TITLE
fix an error caused by SIGKILLing nodes

### DIFF
--- a/rqt_top/src/rqt_top/node_info.py
+++ b/rqt_top/src/rqt_top/node_info.py
@@ -36,16 +36,19 @@ class NodeInfo(object):
     nodes = dict()
     def get_node_info(self, node_name):
         node_api = rosnode.get_api_uri(rospy.get_master(), node_name)
-        code, msg, pid = xmlrpclib.ServerProxy(node_api[2]).getPid(ID)
-        if node_name in self.nodes:
-            return self.nodes[node_name]
-        else:
-            try:
-                p = psutil.Process(pid)
-                self.nodes[node_name] = p
-                return p
-            except:
-                return False
+        try:
+            code, msg, pid = xmlrpclib.ServerProxy(node_api[2]).getPid(ID)
+            if node_name in self.nodes:
+                return self.nodes[node_name]
+            else:
+                try:
+                    p = psutil.Process(pid)
+                    self.nodes[node_name] = p
+                    return p
+                except:
+                    return False
+        except xmlrpclib.socket.error:
+            return False
 
 
     def get_all_node_info(self):
@@ -56,7 +59,6 @@ class NodeInfo(object):
         return infos
 
     def get_all_node_fields(self, fields):
-        # import pdb; pdb.set_trace()
         processes = self.get_all_node_info()
         infos = []
         for name, p in processes:


### PR DESCRIPTION
SIGKILLing a node caused an xmlrpc call to throw a socket error when updating. This caused the plugin to stop updating.
