### PR TITLE
rqt_image_view: properly handle aligned images

### DIFF
--- a/rqt_image_view/src/rqt_image_view/image_view.cpp
+++ b/rqt_image_view/src/rqt_image_view/image_view.cpp
@@ -297,7 +297,7 @@ void ImageView::callbackImage(const sensor_msgs::Image::ConstPtr& msg)
   }
 
   // image must be copied since it uses the conversion_mat_ for storage which is asynchronously overwritten in the next callback invocation
-  QImage image(conversion_mat_.data, conversion_mat_.cols, conversion_mat_.rows, QImage::Format_RGB888);
+  QImage image(conversion_mat_.data, conversion_mat_.cols, conversion_mat_.rows, conversion_mat_.step[0], QImage::Format_RGB888);
   ui_.image_frame->setImage(image);
 
   if (!ui_.zoom_1_push_button->isEnabled())


### PR DESCRIPTION
Image Messages can be aligned where:

``` c++
conversion_mat_.step[0] > conversion_mat_.cols * conversion_mat_.rows * conversion_mat_.elemSize()

```

This change passes the step size on to QImage.
