### PR TITLE
rqt_reconfigure: Fix init order in IntegerEditor

### DIFF
--- a/rqt_reconfigure/src/rqt_reconfigure/param_editors.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/param_editors.py
@@ -176,17 +176,17 @@ class IntegerEditor(EditorWidget):
         self._paramval_lineEdit.setValidator(QIntValidator(self._min,
                                                            self._max, self))
 
+        # TODO: This should not always get set to the default it should be the
+        # current value
+        self._paramval_lineEdit.setText(str(config['default']))
+        self._slider_horizontal.setSliderPosition(int(config['default']))
+
         # Connect slots
         self._paramval_lineEdit.textChanged.connect(self._text_edited)
         self._slider_horizontal.sliderReleased.connect(self._slider_released)
         #self._slider_horizontal.sliderMoved.connect(self._update_text_gui)
         # valueChanged gets called when groove is clicked on.
         #self._slider_horizontal.valueChanged.connect(self.update_value)
-
-        # TODO: This should not always get set to the default it should be the
-        # current value
-        self._paramval_lineEdit.setText(str(config['default']))
-        self._slider_horizontal.setSliderPosition(int(config['default']))
 
     def _text_edited(self):
         self._update_paramserver(int(self._paramval_lineEdit.text()))


### PR DESCRIPTION
If we set to default after the connect() happens, we'll end up bouncing around in a race condition of some kind.

This makes rqt_reconfigure completely unusable on my system. I'm not sure how this isn't effecting more people.

The rest of the editors all set the default BEFORE they connect(), and they seem to work fine.

For a repro' on this one, I used a Hokuyo we had on a robot and changed one of the integer sliders away from the default. I then closed the hokuyo reconfigure box in rqt and re-opened it. The value starts bouncing between the default and the value I set previously for some time. It eventually settles, but not before resetting the value many, many times.
