### PR TITLE
rqt_reconfigure can't take arguments to start of a parameter anymore

### DIFF
--- a/rqt_reconfigure/scripts/rqt_reconfigure
+++ b/rqt_reconfigure/scripts/rqt_reconfigure
@@ -3,6 +3,8 @@
 import sys
 
 from rqt_gui.main import Main
+from rqt_reconfigure.param_plugin import ParamPlugin
 
-main = Main()
-sys.exit(main.main(sys.argv, standalone='rqt_reconfigure'))
+plugin = 'rqt_reconfigure'
+main = Main(filename=plugin)
+sys.exit(main.main(sys.argv, standalone=plugin, plugin_argument_provider=ParamPlugin.add_arguments))

--- a/rqt_reconfigure/src/rqt_reconfigure/node_selector_widget.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/node_selector_widget.py
@@ -146,6 +146,24 @@ class NodeSelectorWidget(QWidget):
                 # Deselect the index.
                 self.selectionModel.select(index, QItemSelectionModel.Deselect)
 
+    def node_selected(self, grn):
+        """
+        Select the index that corresponds to the given GRN.
+
+        :type grn: str
+        """
+
+        # Obtain the corresponding index.
+        qindex_tobe_selected = self._item_model.get_index_from_grn(grn)
+        rospy.logdebug('NodeSelWidt node_selected qindex={} data={}'.format(
+                                qindex_tobe_selected,
+                                qindex_tobe_selected.data(Qt.DisplayRole)))
+
+
+        # Select the index.
+        if qindex_tobe_selected:
+            self.selectionModel.select(qindex_tobe_selected, QItemSelectionModel.Select)
+
     def _selection_deselected(self, index_current, rosnode_name_selected):
         """
         Intended to be called from _selection_changed_slot.

--- a/rqt_reconfigure/src/rqt_reconfigure/param_plugin.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/param_plugin.py
@@ -63,3 +63,9 @@ class ParamPlugin(Plugin):
 
     def restore_settings(self, plugin_settings, instance_settings):
         self._widget.restore_settings(plugin_settings, instance_settings)
+
+    @staticmethod
+    def add_arguments(parser):
+        group = parser.add_argument_group('Options for rqt_reconfigure plugin')
+        group.add_argument('node_name', nargs='*', default=[], help='Node(s) to open automatically')
+


### PR DESCRIPTION
Before we could do:
rosrun dynamic_reconfigure reconfigure_gui /someparam

And the window would get initialized in that /someparam tree, that was very useful.
This behaviour doesn't exist anymore.
I tried to look into the code to try to "patch" it... but I don't really get what is happening :( I'm sorry.
