### PR TITLE
rqt_plot: decreased required minimum padding to 0

### DIFF
--- a/rqt_plot/src/rqt_plot/mat_data_plot.py
+++ b/rqt_plot/src/rqt_plot/mat_data_plot.py
@@ -156,7 +156,7 @@ class MatDataPlot(QWidget):
 
         if self._autoscroll and ymin is not None:
             # pad the min/max
-            delta = max(ymax - ymin, 0.1)
+            delta = ymax - ymin if ymax != ymin else 0.1
             ymin -= .05 * delta
             ymax += .05 * delta
 


### PR DESCRIPTION
With a fixed absolute minimum padding, rqt_plot is useless for plotting
arbitrarily small values. (For example, trying to plot a magnetic field
measured in teslas, usually having a magnitude of about 1e-4.)
