### PR TITLE
rqt_reconfigure: Removing unnecessary margins which make rqt_reconfigure useless on small screens

### DIFF
--- a/rqt_reconfigure/resource/editor_bool.ui
+++ b/rqt_reconfigure/resource/editor_bool.ui
@@ -13,13 +13,16 @@
   <property name="minimumSize">
    <size>
     <width>300</width>
-    <height>30</height>
+    <height>20</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Param</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="_layout_h" stretch="0,0">
      <item>

--- a/rqt_reconfigure/resource/editor_enum.ui
+++ b/rqt_reconfigure/resource/editor_enum.ui
@@ -20,6 +20,9 @@
    <string>Param</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="_layout_h" stretch="0,4">
      <item>

--- a/rqt_reconfigure/resource/editor_number.ui
+++ b/rqt_reconfigure/resource/editor_number.ui
@@ -13,13 +13,16 @@
   <property name="minimumSize">
    <size>
     <width>300</width>
-    <height>30</height>
+    <height>20</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Param</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="_layout_h" stretch="0,0,1,0,0">
      <item>

--- a/rqt_reconfigure/resource/editor_string.ui
+++ b/rqt_reconfigure/resource/editor_string.ui
@@ -13,13 +13,16 @@
   <property name="minimumSize">
    <size>
     <width>300</width>
-    <height>30</height>
+    <height>20</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Param string</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="_layout_h" stretch="0,0">
      <item>

--- a/rqt_reconfigure/resource/node_selector.ui
+++ b/rqt_reconfigure/resource/node_selector.ui
@@ -11,6 +11,9 @@
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>

--- a/rqt_reconfigure/resource/paramedit_pane.ui
+++ b/rqt_reconfigure/resource/paramedit_pane.ui
@@ -20,6 +20,9 @@
    <string>Param</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QVBoxLayout" name="vlayout">
      <item>

--- a/rqt_reconfigure/src/rqt_reconfigure/param_groups.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/param_groups.py
@@ -34,7 +34,7 @@
 
 import time
 
-from python_qt_binding.QtCore import QSize, Qt, Signal
+from python_qt_binding.QtCore import QSize, Qt, Signal, QMargins
 from python_qt_binding.QtGui import (QFont, QFormLayout, QHBoxLayout, QIcon,
                                      QGroupBox, QLabel, QPushButton,
                                      QTabWidget, QVBoxLayout, QWidget)
@@ -112,9 +112,11 @@ class GroupWidget(QWidget):
 #        loadUi(ui_file, self)
 
         verticalLayout = QVBoxLayout(self)
+        verticalLayout.setContentsMargins(QMargins(0, 0, 0, 0))
 
         _widget_nodeheader = QWidget()
         _h_layout_nodeheader = QHBoxLayout(_widget_nodeheader)
+        _h_layout_nodeheader.setContentsMargins(QMargins(0, 0, 0, 0))
 
         self.nodename_qlabel = QLabel(self)
         font = QFont('Trebuchet MS, Bold')

--- a/rqt_reconfigure/src/rqt_reconfigure/param_widget.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/param_widget.py
@@ -37,7 +37,7 @@ from __future__ import division
 import rospkg
 import sys
 
-from python_qt_binding.QtCore import Signal
+from python_qt_binding.QtCore import Signal, QMargins
 from python_qt_binding.QtGui import (QLabel, QHBoxLayout, QSplitter,
                                      QVBoxLayout, QWidget)
 
@@ -79,6 +79,7 @@ class ParamWidget(QWidget):
         #            I decided not use .ui in this class.
         #            If someone can tackle this I'd appreciate.
         _hlayout_top = QHBoxLayout(self)
+        _hlayout_top.setContentsMargins(QMargins(0, 0, 0, 0))
         self._splitter = QSplitter(self)
         _hlayout_top.addWidget(self._splitter)
 


### PR DESCRIPTION
This removes all the extra padding from rqt_reconfigure. It makes it usable on small screens.

In the attached image, the current version is above, and the patched version is below. Each window is given the same exact screen space:

![rqt_reconfigure_compact](https://cloud.githubusercontent.com/assets/1253450/2989586/91339f56-dc65-11e3-8c71-312d3a47e776.png)
