### PR TITLE
Fix closing and reopning rqt_bag topic views

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -93,7 +93,7 @@ class BagTimeline(QGraphicsScene):
 
         # Plugin popup management
         self._context = context
-        self.popups = set()
+        self.popups = {}
         self._views = []
         self._listeners = {}
 
@@ -133,7 +133,8 @@ class BagTimeline(QGraphicsScene):
         for bag in self._bags:
             bag.close()
         for _, frame in self._views:
-            self._context.remove_widget(frame)
+            if frame.parent():
+                self._context.remove_widget(frame)
 
     # Bag Management and access
     def add_bag(self, bag):
@@ -684,13 +685,6 @@ class BagTimeline(QGraphicsScene):
     def add_view(self, topic, view, frame):
         self._views.append((view, frame))
         self.add_listener(topic, view)
-
-    def remove_view(self, topic, view):
-        self.remove_listener(topic, view)
-        for entry in self._views:
-            if entry[0] == view:
-                self._views.remove(entry)
-        self.update()
 
     def has_listeners(self, topic):
         return topic in self._listeners

--- a/rqt_bag/src/rqt_bag/plugins/topic_message_view.py
+++ b/rqt_bag/src/rqt_bag/plugins/topic_message_view.py
@@ -45,7 +45,6 @@ class TopicMessageView(MessageView):
         self._topic = None
         self._stamp = None
         self._name = parent.objectName()
-        self.parent.destroyed.connect(self._on_close)
 
         self.toolbar = QToolBar()
         self._first_action = QAction(QIcon.fromTheme('go-first'), '', self.toolbar)
@@ -80,12 +79,6 @@ class TopicMessageView(MessageView):
         self._topic, _, self._stamp = msg_details[:3]
 
     # Events
-    def _on_close(self):
-        # TODO: needs to handle closing when a message hasn't been viewed yet
-        if self._topic:
-            self.timeline.popups.remove(self._name)
-            self.timeline.remove_view(self._topic, self)
-
     def navigate_first(self):
         if not self.topic:
             return


### PR DESCRIPTION
This addresses several bugs:
- It wasn't possible to close topic views when running standalone
- If topic views were closed (non-standalone), it wasn't possible to
  open them again

This also moves the logic for handling open/close interactions out of
the TopicMessageView class, where they might not always be called, and
into the owning class instead
