### PR TITLE
Bugfix no-change when detecting infinite values

### DIFF
--- a/rqt_reconfigure/src/rqt_reconfigure/param_editors.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/param_editors.py
@@ -260,14 +260,14 @@ class DoubleEditor(EditorWidget):
             self._min = float(config['min'])
             self._min_val_label.setText(str(self._min))
         else:
-            self._min = -1e10000
+            self._min = -1e100
             self._min_val_label.setText('-inf')
 
         if config['max'] != float('inf'):
             self._max = float(config['max'])
             self._max_val_label.setText(str(self._max))
         else:
-            self._max = 1e10000
+            self._max = 1e100
             self._max_val_label.setText('inf')
 
         if config['min'] != -float('inf') and config['max'] != -float('inf'):


### PR DESCRIPTION
This code detects for a double having the value `inf` and applies a suitably large real number in its place. Originally `1e10000`, however python just converts this back to `inf`.

You can validate this behaviour for python2.7 on precise and trusty by opening a python shell and typing `print 1e10000`. `1e100` seems to work though.
