### PR TITLE
rqt_reconfigure: Fix bug in float range calculations

### DIFF
--- a/rqt_reconfigure/src/rqt_reconfigure/param_editors.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/param_editors.py
@@ -270,7 +270,7 @@ class DoubleEditor(EditorWidget):
             self._max = 1e10000
             self._max_val_label.setText('inf')
 
-        if config['min'] != -float('inf') and config['max'] != -float('inf'):
+        if config['min'] != -float('inf') and config['max'] != float('inf'):
             self._func = lambda x: x
             self._ifunc = self._func
         else:


### PR DESCRIPTION
This only affected float parameters in which the minimum was well defined but
the maximum was infinite.

This fixes the behaviour described in https://github.com/ros-visualization/rqt_common_plugins/pull/240
