### PR TITLE
Add plot markers option to plotting backends

### DIFF
--- a/rqt_plot/package.xml
+++ b/rqt_plot/package.xml
@@ -18,7 +18,7 @@
   <run_depend>python-matplotlib</run_depend>
   <run_depend>python-qt-bindings-qwt5</run_depend>
   <run_depend>python-rospkg</run_depend>
-  <run_depend>qt_gui_py_common</run_depend>
+  <run_depend version_gte="0.2.25">qt_gui_py_common</run_depend>
   <run_depend>rosgraph</run_depend>
   <run_depend>rostopic</run_depend>
   <run_depend>rqt_gui</run_depend>

--- a/rqt_plot/src/rqt_plot/data_plot/mat_data_plot.py
+++ b/rqt_plot/src/rqt_plot/data_plot/mat_data_plot.py
@@ -79,8 +79,6 @@ class MatDataPlot(QWidget):
             super(MatDataPlot.Canvas, self).resizeEvent(event)
             self.figure.tight_layout()
 
-    _colors = [Qt.red, Qt.blue, Qt.magenta, Qt.cyan, Qt.green, Qt.darkYellow, Qt.black, Qt.darkRed, Qt.gray, Qt.darkCyan]
-
     limits_changed = Signal()
 
     def __init__(self, parent=None):
@@ -92,7 +90,6 @@ class MatDataPlot(QWidget):
         vbox.addWidget(self._canvas)
         self.setLayout(vbox)
 
-        self._color_index = 0
         self._curves = {}
         self._current_vline = None
         self._canvas.mpl_connect('button_release_event', self._limits_changed)
@@ -100,13 +97,16 @@ class MatDataPlot(QWidget):
     def _limits_changed(self, event):
         self.limits_changed.emit()
 
-    def add_curve(self, curve_id, curve_name):
-        color = QColor(self._colors[self._color_index % len(self._colors)])
-        self._color_index += 1
+    def add_curve(self, curve_id, curve_name, curve_color=QColor(Qt.blue), markers_on=False):
+
         # adding an empty curve and change the limits, so save and restore them
         x_limits = self.get_xlim()
         y_limits = self.get_ylim()
-        line = self._canvas.axes.plot([], [], label=curve_name, linewidth=1, picker=5, color=color.name())[0]
+        if markers_on:
+            marker_size = 3
+        else:
+            marker_size = 0
+        line = self._canvas.axes.plot([], [], 'o-', markersize=marker_size, label=curve_name, linewidth=1, picker=5, color=curve_color.name())[0]
         self._curves[curve_id] = line
         self._update_legend()
         self.set_xlim(x_limits)

--- a/rqt_plot/src/rqt_plot/data_plot/pyqtgraph_data_plot.py
+++ b/rqt_plot/src/rqt_plot/data_plot/pyqtgraph_data_plot.py
@@ -33,12 +33,11 @@
 from python_qt_binding.QtCore import Slot, Qt, qWarning, Signal
 from python_qt_binding.QtGui import QColor, QVBoxLayout, QWidget
 
-from pyqtgraph import PlotWidget, mkPen
+from pyqtgraph import PlotWidget, mkPen, mkBrush
 import numpy
 
 
 class PyQtGraphDataPlot(QWidget):
-    _colors = [Qt.red, Qt.blue, Qt.magenta, Qt.cyan, Qt.green, Qt.darkYellow, Qt.black, Qt.darkRed, Qt.gray, Qt.darkCyan]
 
     limits_changed = Signal()
 
@@ -53,16 +52,19 @@ class PyQtGraphDataPlot(QWidget):
         self.setLayout(vbox)
         self._plot_widget.getPlotItem().sigRangeChanged.connect(self.limits_changed)
 
-        self._color_index = 0
         self._curves = {}
         self._current_vline = None
 
-    def add_curve(self, curve_id, curve_name):
-        color = QColor(self._colors[self._color_index % len(self._colors)])
-        self._color_index += 1
-        pen = mkPen(color, width=2)
+    def add_curve(self, curve_id, curve_name, curve_color=QColor(Qt.blue), markers_on=False):
+        pen = mkPen(curve_color, width=1)
+        symbol = "o"
+        symbolPen = mkPen(QColor(Qt.black))
+        symbolBrush = mkBrush(curve_color)
         # this adds the item to the plot and legend
-        plot = self._plot_widget.plot(name=curve_name, pen=pen)
+        if markers_on:
+            plot = self._plot_widget.plot(name=curve_name, pen=pen, symbol=symbol, symbolPen=symbolPen, symbolBrush=symbolBrush, symbolSize=4)
+        else:
+            plot = self._plot_widget.plot(name=curve_name, pen=pen)
         self._curves[curve_id] = plot
 
     def remove_curve(self, curve_id):

--- a/rqt_plot/src/rqt_plot/data_plot/qwt_data_plot.py
+++ b/rqt_plot/src/rqt_plot/data_plot/qwt_data_plot.py
@@ -35,8 +35,8 @@ from __future__ import division
 import math
 import sys
 
-from python_qt_binding.QtCore import QEvent, QPointF, Qt, SIGNAL, Signal, Slot, qWarning
-from python_qt_binding.QtGui import QPen, QVector2D
+from python_qt_binding.QtCore import QEvent, QSize, QPointF, Qt, SIGNAL, Signal, Slot, qWarning
+from python_qt_binding.QtGui import QColor, QPen, QBrush, QVector2D
 import Qwt
 
 from numpy import arange, zeros, concatenate
@@ -45,7 +45,6 @@ from numpy import arange, zeros, concatenate
 # create real QwtDataPlot class
 class QwtDataPlot(Qwt.QwtPlot):
     mouseCoordinatesChanged = Signal(QPointF)
-    _colors = [Qt.red, Qt.blue, Qt.magenta, Qt.cyan, Qt.green, Qt.darkYellow, Qt.black, Qt.darkRed, Qt.gray, Qt.darkCyan]
     _num_value_saved = 1000
     _num_values_ploted = 1000
 
@@ -72,7 +71,6 @@ class QwtDataPlot(Qwt.QwtPlot):
         self._pressed_canvas_y = 0
         self._pressed_canvas_x = 0
         self._last_click_coordinates = None
-        self._color_index = 0
 
         marker_axis_y = Qwt.QwtPlotMarker()
         marker_axis_y.setLabelAlignment(Qt.AlignRight | Qt.AlignTop)
@@ -84,8 +82,8 @@ class QwtDataPlot(Qwt.QwtPlot):
             Qwt.QwtPlot.xBottom, Qwt.QwtPlot.yLeft, Qwt.QwtPicker.PolygonSelection,
             Qwt.QwtPlotPicker.PolygonRubberBand, Qwt.QwtPicker.AlwaysOn, self.canvas()
         )
-        self._picker.setRubberBandPen(QPen(self._colors[-1]))
-        self._picker.setTrackerPen(QPen(self._colors[-1]))
+        self._picker.setRubberBandPen(QPen(Qt.blue))
+        self._picker.setTrackerPen(QPen(Qt.blue))
 
         # Initialize data
         self.rescale()
@@ -120,14 +118,15 @@ class QwtDataPlot(Qwt.QwtPlot):
         Qwt.QwtPlot.resizeEvent(self, event)
         self.rescale()
 
-    def add_curve(self, curve_id, curve_name):
+    def add_curve(self, curve_id, curve_name, curve_color=QColor(Qt.blue), markers_on=False):
         curve_id = str(curve_id)
         if curve_id in self._curves:
             return
         curve_object = Qwt.QwtPlotCurve(curve_name)
         curve_object.attach(self)
-        curve_object.setPen(QPen(self._colors[self._color_index % len(self._colors)]))
-        self._color_index += 1
+        curve_object.setPen(curve_color)
+        if markers_on:
+            curve_object.setSymbol(Qwt.QwtSymbol(Qwt.QwtSymbol.Ellipse, QBrush(curve_color), QPen(Qt.black), QSize(4,4)))
         self._curves[curve_id] = curve_object
 
     def remove_curve(self, curve_id):


### PR DESCRIPTION
This adds the ability to use plot markers for rqt_plot and rqt_bag for any of the available backends.  Markers are off by default but can be enabled through the backend selection dialog box.  This is most useful in rqt_bag where the plotting resolution can be modified, but may also be used in rqt_plot.  The markers appear to add quite a bit of processing in PyQtGraph, so I've added a message indicating it may add significant load for rqt_plot.

This PR depends on version 0.2.25 of <code>qt_gui_core</code>.
