### PR TITLE
Export architecture_independent flag in package.xml

### DIFF
--- a/rqt_action/package.xml
+++ b/rqt_action/package.xml
@@ -28,6 +28,7 @@
   <run_depend>rqt_py_common</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_bag/package.xml
+++ b/rqt_bag/package.xml
@@ -25,6 +25,7 @@
   <run_depend>rqt_gui_py</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_bag_plugins/package.xml
+++ b/rqt_bag_plugins/package.xml
@@ -28,6 +28,7 @@
   <run_depend>std_msgs</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_bag plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_console/package.xml
+++ b/rqt_console/package.xml
@@ -21,6 +21,7 @@
   <run_depend>rqt_logger_level</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_dep/package.xml
+++ b/rqt_dep/package.xml
@@ -24,6 +24,7 @@
   <test_depend>python-mock</test_depend>
 
   <export>
+    <architecture_independent/>
     <qt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_graph/package.xml
+++ b/rqt_graph/package.xml
@@ -34,6 +34,7 @@
   <run_depend>rqt_gui_py</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_launch/package.xml
+++ b/rqt_launch/package.xml
@@ -26,6 +26,7 @@
   <run_depend>rqt_py_common</run_depend>
 
   <export>
+    <architecture_independent/>
 		<rqt_gui plugin="${prefix}/plugin.xml" />
   </export>
 </package>

--- a/rqt_logger_level/package.xml
+++ b/rqt_logger_level/package.xml
@@ -25,6 +25,7 @@
   <run_depend>rqt_gui_py</run_depend>
 
   <export>
+    <architecture_independent/>
       <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_msg/package.xml
+++ b/rqt_msg/package.xml
@@ -27,6 +27,7 @@
   <run_depend>rqt_console</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_plot/package.xml
+++ b/rqt_plot/package.xml
@@ -26,6 +26,7 @@
   <run_depend>rqt_py_common</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_publisher/package.xml
+++ b/rqt_publisher/package.xml
@@ -23,6 +23,7 @@
   <run_depend>rqt_py_common</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_py_common/package.xml
+++ b/rqt_py_common/package.xml
@@ -32,4 +32,8 @@
   rosaction gets moved to actionlib. -->
   <run_depend>actionlib</run_depend>
   <run_depend>rosbag</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/rqt_py_console/package.xml
+++ b/rqt_py_console/package.xml
@@ -22,6 +22,7 @@
   <run_depend>rqt_gui_py</run_depend>
 
   <export>
+    <architecture_independent/>
     <qt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_reconfigure/package.xml
+++ b/rqt_reconfigure/package.xml
@@ -32,6 +32,7 @@
 	<run_depend>rqt_gui_py</run_depend>
 	<run_depend>rqt_py_common</run_depend>
 	<export>
+		<architecture_independent/>
 		<rqt_gui plugin="${prefix}/plugin.xml" />
 	</export>
 </package>

--- a/rqt_service_caller/package.xml
+++ b/rqt_service_caller/package.xml
@@ -21,6 +21,7 @@
   <run_depend>rqt_py_common</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_shell/package.xml
+++ b/rqt_shell/package.xml
@@ -21,6 +21,7 @@
   <run_depend>rqt_gui_py</run_depend>
 
   <export>
+    <architecture_independent/>
     <qt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_srv/package.xml
+++ b/rqt_srv/package.xml
@@ -23,6 +23,7 @@
   <run_depend>rqt_msg</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_top/package.xml
+++ b/rqt_top/package.xml
@@ -20,6 +20,7 @@
   <run_depend>rqt_gui_py</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_topic/package.xml
+++ b/rqt_topic/package.xml
@@ -21,6 +21,7 @@
   <run_depend>std_msgs</run_depend>
 
   <export>
+    <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_web/package.xml
+++ b/rqt_web/package.xml
@@ -21,6 +21,7 @@
   <run_depend>rqt_gui_py</run_depend>
 
   <export>
+    <architecture_independent/>
     <qt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>


### PR DESCRIPTION
These packages don't have any binaries in them, so they can be marked as architecture independent.

Tested on the RPM buildfarm (http://csc.mcs.sdsmt.edu/jenkins/):
- [x] No regressions
- [x] No binaries installed

See:
- https://github.com/ros/rosdistro/issues/4037
- https://github.com/ros-infrastructure/bloom/pull/270
- http://www.ros.org/reps/rep-0127.html#architecture-independent

Thanks!
