### PR TITLE
remove experimental suffix from rqt_reconfigure

### DIFF
--- a/rqt_reconfigure/plugin.xml
+++ b/rqt_reconfigure/plugin.xml
@@ -9,7 +9,7 @@
         <icon type="theme">folder</icon>
         <statustip>Plugins related to configuration.</statustip>
       </group>
-      <label>Dynamic Reconfigure (experimental)</label>
+      <label>Dynamic Reconfigure</label>
       <icon type="theme">accessories-text-editor</icon>
       <statustip>A Python GUI for viewing and editing dynamic_reconfigure parameters.</statustip>
     </qtgui>


### PR DESCRIPTION
@cottsay Do you agree that the plugin is now stable enough to remove the "experimental" suffix?
