### PR TITLE
Add directories to setup.py, CMakeLists.txt

### DIFF
--- a/rqt_bag_plugins/CMakeLists.txt
+++ b/rqt_bag_plugins/CMakeLists.txt
@@ -8,3 +8,7 @@ catkin_python_setup()
 install(FILES plugin.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+
+install(DIRECTORY resource
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/rqt_plot/setup.py
+++ b/rqt_plot/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-    packages=['rqt_plot'],
+    packages=['rqt_plot', 'rqt_plot.data_plot'],
     package_dir={'': 'src'},
     scripts=['scripts/rqt_plot']
 )


### PR DESCRIPTION
Two new directories from #239 didn't make it into the setup.py and CMakeLists.txt files which breaks the distributed binaries.
