### PR TITLE
White background to contrast with black pens

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -99,6 +99,9 @@ class BagTimeline(QGraphicsScene):
         self._listeners = {}
 
         # Initialize scene
+        # the timeline renderer fixes use of black pens and fills, so ensure we fix white here for contrast.
+        # otherwise a dark qt theme will default it to black and the frame render pen will be unreadable
+        self.setBackgroundBrush(Qt.white)
         self._timeline_frame = TimelineFrame()
         self._timeline_frame.setPos(0, 0)
         self.addItem(self._timeline_frame)


### PR DESCRIPTION
In a dark qt theme, the default background for the graphics scene will be black. Since the frame renderer uses black pens, this leaves it unreadable. So fix the background brush to white here.

See also https://github.com/ros-visualization/rqt/pull/40/files
