### PR TITLE
fixes #266 : nodes are now allowed to create namespaces

### DIFF
--- a/rqt_graph/src/rqt_graph/dotcode.py
+++ b/rqt_graph/src/rqt_graph/dotcode.py
@@ -498,9 +498,10 @@ class RosGraphDotcodeGenerator:
             for n in nn_nodes:
                 if (cluster_namespaces_level > 0 and
                     str(n).count('/') >= 1 and
-                    len(str(n).split('/')[1]) > 0 and
-                    str(n).split('/')[1] in namespace_clusters):
+                    len(str(n).split('/')[1]) > 0):
                     namespace = str(n).split('/')[1]
+                    if namespace not in namespace_clusters:
+                        namespace_clusters[namespace] = dotcode_factory.add_subgraph_to_graph(dotgraph, namespace, rank=rank, rankdir=orientation, simplify=simplify)
                     self._add_node(n, rosgraphinst=rosgraphinst, dotcode_factory=dotcode_factory, dotgraph=namespace_clusters[namespace], quiet=quiet)
                 else:
                     self._add_node(n, rosgraphinst=rosgraphinst, dotcode_factory=dotcode_factory, dotgraph=dotgraph, quiet=quiet)


### PR DESCRIPTION
Took a moment to look at this.
It seems when rqt_graph adds nodes/topics to the graph it only allows the topic code to create the namespaces. This works most of the time save for the case shown in #266.

This code allows nodes to add namespaces too.
