### PR TITLE
rqt_bag: Fix topic type retrieval for multiple bag files

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -230,7 +230,8 @@ class BagTimeline(QGraphicsScene):
                 bag_datatype = bag_helper.get_datatype(bag, topic)
                 if datatype and bag_datatype and (bag_datatype != datatype):
                     raise Exception('topic %s has multiple datatypes: %s and %s' % (topic, datatype, bag_datatype))
-                datatype = bag_datatype
+                if bag_datatype:
+                    datatype = bag_datatype
             return datatype
 
     def get_entries(self, topics, start_stamp, end_stamp):


### PR DESCRIPTION
Fix a bug where get_datatype would return None if the last bag didn't contain the topic in question.

This was causing bag plugins for specific datatypes to fail to enumerate properly in the `View (By Topic)` context menu.
