### PR TITLE
rqt_bag: Refactor popup management and close callbacks

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -136,7 +136,7 @@ class BagTimeline(QGraphicsScene):
         self._timeline_frame.handle_close()
         for bag in self._bags:
             bag.close()
-        for _, frame in self._views:
+        for frame in self._views:
             if frame.parent():
                 self._context.remove_widget(frame)
 
@@ -686,9 +686,8 @@ class BagTimeline(QGraphicsScene):
                     qWarning('Error calling timeline_changed on %s: %s' % (type(listener), str(ex)))
 
     ### Views / listeners
-    def add_view(self, topic, view, frame):
-        self._views.append((view, frame))
-        self.add_listener(topic, view)
+    def add_view(self, topic, frame):
+        self._views.append(frame)
 
     def has_listeners(self, topic):
         return topic in self._listeners


### PR DESCRIPTION
Update how popup windows are managed, so that the popup's close() function is called when it's hidden, and a new popup is created when the user asks to display it again.

This is to support properly closing child windows in the rqt_robot_monitor bag plugin.
