### PR TITLE
rqt_bag: Make the right-click menu more useful

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -451,7 +451,8 @@ class BagTimeline(QGraphicsScene):
         elif event.buttons() == Qt.MidButton:
             self._timeline_frame.on_middle_down(event)
         elif event.buttons() == Qt.RightButton:
-            TimelinePopupMenu(self, event)
+            topic = self._timeline_frame.map_y_to_topic(event.y())
+            TimelinePopupMenu(self, event, topic)
 
     def on_mouse_up(self, event):
         self._timeline_frame.on_mouse_up(event)

--- a/rqt_bag/src/rqt_bag/timeline_frame.py
+++ b/rqt_bag/src/rqt_bag/timeline_frame.py
@@ -907,6 +907,13 @@ class TimelineFrame(QGraphicsItem):
     def map_dstamp_to_dx(self, dstamp):
         return (float(dstamp) * self._history_width) / (self._stamp_right - self._stamp_left)
 
+    def map_y_to_topic(self, y):
+        for topic in self._history_bounds:
+            x, topic_y, w, topic_h = self._history_bounds[topic]
+            if y > topic_y and y <= topic_y + topic_h:
+                return topic
+        return None
+
     # View port manipulation functions
     def reset_timeline(self):
         self.reset_zoom()


### PR DESCRIPTION
Clicking on a topic in the timeline brings up a menu for showing thumbnails, viewing, and publishing only that topic.

Clicking outside the topic area displays the original menu with the full list of options and topics.
