### PR TITLE
rqt_reconfigure: Restore support for parameter groups

### DIFF
--- a/rqt_reconfigure/src/rqt_reconfigure/dynreconf_client_widget.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/dynreconf_client_widget.py
@@ -35,7 +35,7 @@
 import rospy
 
 from .param_editors import EditorWidget
-from .param_groups import GroupWidget
+from .param_groups import GroupWidget, find_cfg
 from .param_updater import ParamUpdater
 
 
@@ -85,7 +85,7 @@ class DynreconfClientWidget(GroupWidget):
                                        widget.param_name)
                         widget.update_value(config[widget.param_name])
                 elif isinstance(widget, GroupWidget):
-                    cfg = self.find_cfg(config, widget.param_name)
+                    cfg = find_cfg(config, widget.param_name)
                     rospy.logdebug('GROUP widget.param_name=%s',
                                    widget.param_name)
                     widget.update_group(cfg)


### PR DESCRIPTION
I finally got around to restoring group support in `rqt_reconfigure`. From what I can tell, groups were broken by a few commit in January of 2013, and haven't worked right since. Groups currently do not work _at all_, and the only included change outside `param_groups.py` is a trivial one, so I don't expect any serious regressions.

I tried to restore the original intent for the base types (tab, collapse, apply, hidden, box) with box being the default for any unknown types. I haven't added any new group types...yet...

I've done all of my testing using a dynamic reconfigure test project [1] that I created. Feel free to use it to demonstrate the functionality of each type.

I have uncovered two bugs in the python implementation of the `dynamic_reconfigure` client. They present themselves as:
1. ~~Python exception when enabling or disabling a group (primarily visible for the `collapse` type)~~ fixed by (https://github.com/ros/dynamic_reconfigure/issues/43)
2. Groups do not maintain order like parameters do (pending as https://github.com/ros/dynamic_reconfigure/issues/44)

~~I'll file~~ **I have filed** bugs for these in `dynamic_reconfigure`.

This Fixes https://github.com/ros-visualization/rqt_common_plugins/issues/162
FYI https://github.com/ros-drivers/prosilica_driver/issues/5

Thanks,

--scott

[1] https://github.com/cottsay/dyn_re_test
