### PR TITLE
Fix version clash when PyQt5 is installed

### DIFF
--- a/rqt_plot/src/rqt_plot/data_plot/mat_data_plot.py
+++ b/rqt_plot/src/rqt_plot/data_plot/mat_data_plot.py
@@ -51,6 +51,7 @@ if matplotlib.__version__ < '1.1.0':
     raise ImportError('A newer matplotlib is required (at least 1.1.0)')
 
 try:
+    matplotlib.use('Qt4Agg')
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 except ImportError:
     # work around bug in dateutil


### PR DESCRIPTION
When PyQt5 is installed, matplotlib uses the Qt5 backend by default, so we need to force the usage of the Qt4 backend.