### PR TITLE
rqt_reconfigure: Fix background colors for dark themes

### DIFF
--- a/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
@@ -110,7 +110,8 @@ class ParameditWidget(QWidget):
 
         # Add color to alternate the rim of the widget.
         LayoutUtil.alternate_color(self._dynreconf_clients.itervalues(),
-                                   [Qt.white, Qt.lightGray])
+                                   [self.palette().background().color().lighter(125),
+                                    self.palette().background().color().darker(125)])
 
     def close(self):
         for dc in self._dynreconf_clients:


### PR DESCRIPTION
Instead of specifically specifying the background color to make the colors alternate, modify the theme's set background color to be "lighter" and "darker".

Values chosen to most closely resemble the current behavior with a light theme.

Suggested fix for https://github.com/ros-visualization/rqt_common_plugins/pull/293

Tested on Ubuntu Trusty and Fedora 21 with light and dark themes.

Screenshot with Adwaita dark style theme:
![rqt_reconfigure dark](https://cloud.githubusercontent.com/assets/1144588/5915297/d0d55e20-a5b8-11e4-8d6c-d744b8f21dac.png)

**EDIT**: Screenshot with Adwaita dark style theme before fix:
![rqt_reconfigure broken](https://cloud.githubusercontent.com/assets/1144588/5915530/c6fd88ac-a5bb-11e4-8685-acab3f7930b5.png)

**EDIT**: Screenshot with Adwaita light theme after fix (no significant difference) :
![rqt_reconfigure light](https://cloud.githubusercontent.com/assets/1144588/5915448/c9296cf0-a5ba-11e4-9a31-c3bc1a00d849.png)