### PR TITLE
Feature plot: title and legends

### DIFF
--- a/rqt_plot/src/rqt_plot/plot.py
+++ b/rqt_plot/src/rqt_plot/plot.py
@@ -118,7 +118,7 @@ class Plot(Plugin):
     def save_settings(self, plugin_settings, instance_settings):
         self._data_plot.save_settings(plugin_settings, instance_settings)
         instance_settings.set_value('autoscroll', self._widget.autoscroll_checkbox.isChecked())
-        instance_settings.set_value('topics', pack(self._widget._rosdata.keys()))
+        instance_settings.set_value('topics', pack(self._widget._ordered_topics))
 
     def restore_settings(self, plugin_settings, instance_settings):
         autoscroll = instance_settings.value('autoscroll', True) in [True, 'true']

--- a/rqt_plot/src/rqt_plot/plot.py
+++ b/rqt_plot/src/rqt_plot/plot.py
@@ -69,7 +69,7 @@ class Plot(Plugin):
         self._data_plot.set_xlim([0, 10.0])
 
         self._widget.switch_data_plot_widget(self._data_plot)
-        self._update_title(self._title)
+        self._update_title()
         context.add_widget(self._widget)
 
     def _parse_args(self, argv):
@@ -122,7 +122,8 @@ class Plot(Plugin):
                            help='Window title')
         group.add_argument('topics', nargs='*', default=[], help='Topics to plot')
 
-    def _update_title(self, title):
+    def _update_title(self):
+        title = self._title
         if title is None or title == '':
             title = self._data_plot.getTitle()
         self._widget.setWindowTitle(title)
@@ -145,7 +146,9 @@ class Plot(Plugin):
 
         self._data_plot.restore_settings(plugin_settings, instance_settings)
         title = instance_settings.value('title', '')
-        self._update_title(title)
+        if self._title is None or self._title == '':
+            self._title = title
+        self._update_title()
 
         if len(self._widget._rosdata.keys()) == 0 and not self._args.start_empty:
             topics = unpack(instance_settings.value('topics', []))
@@ -161,7 +164,7 @@ class Plot(Plugin):
 
     def trigger_configuration(self):
         self._data_plot.doSettingsDialog()
-        self._update_title(self._title)
+        self._update_title()
 
     def shutdown_plugin(self):
         self._widget.clean_up_subscribers()

--- a/rqt_plot/src/rqt_plot/plot_widget.py
+++ b/rqt_plot/src/rqt_plot/plot_widget.py
@@ -136,6 +136,7 @@ class PlotWidget(QWidget):
 
         self._start_time = rospy.get_time()
         self._rosdata = {}
+        self._ordered_topics = []
         self._remove_topic_menu = QMenu()
 
         # init and start update timer for plot
@@ -281,6 +282,7 @@ class PlotWidget(QWidget):
                 qWarning(str(self._rosdata[topic_name].error))
                 del self._rosdata[topic_name]
             else:
+                self._ordered_topics.append(topic_name)
                 data_x, data_y = self._rosdata[topic_name].next()
                 self.data_plot.add_curve(topic_name, topic_name, data_x, data_y)
                 topics_changed = True
@@ -291,6 +293,7 @@ class PlotWidget(QWidget):
     def remove_topic(self, topic_name):
         self._rosdata[topic_name].close()
         del self._rosdata[topic_name]
+        self._ordered_topics.remove(topic_name)
         self.data_plot.remove_curve(topic_name)
 
         self._subscribed_topics_changed()

--- a/rqt_plot/src/rqt_plot/plot_widget.py
+++ b/rqt_plot/src/rqt_plot/plot_widget.py
@@ -111,11 +111,12 @@ def is_plottable(topic_name):
 class PlotWidget(QWidget):
     _redraw_interval = 40
 
-    def __init__(self, initial_topics=None, start_paused=False):
+    def __init__(self, initial_topics=None, labels={}, start_paused=False):
         super(PlotWidget, self).__init__()
         self.setObjectName('PlotWidget')
 
         self._initial_topics = initial_topics
+        self._labels = labels
 
         rp = rospkg.RosPack()
         ui_file = os.path.join(rp.get_path('rqt_plot'), 'resource', 'plot.ui')
@@ -160,7 +161,10 @@ class PlotWidget(QWidget):
 
         if self._initial_topics:
             for topic_name in self._initial_topics:
-                self.add_topic(topic_name)
+                try:
+                    self.add_topic(topic_name, self._labels[topic_name])
+                except KeyError:
+                    self.add_topic(topic_name)
             self._initial_topics = None
         else:
             for topic_name, rosdata in self._rosdata.items():
@@ -271,7 +275,9 @@ class PlotWidget(QWidget):
 
         self.remove_topic_button.setMenu(self._remove_topic_menu)
 
-    def add_topic(self, topic_name):
+    def add_topic(self, topic_name, label=None):
+        if label is None:
+            label = topic_name
         topics_changed = False
         for topic_name in get_plot_fields(topic_name)[0]:
             if topic_name in self._rosdata:
@@ -284,7 +290,7 @@ class PlotWidget(QWidget):
             else:
                 self._ordered_topics.append(topic_name)
                 data_x, data_y = self._rosdata[topic_name].next()
-                self.data_plot.add_curve(topic_name, topic_name, data_x, data_y)
+                self.data_plot.add_curve(topic_name, label, data_x, data_y)
                 topics_changed = True
 
         if topics_changed:


### PR DESCRIPTION
This feature adds the following functionality in three commits:
The order of the topics are now remembered and consistent through launches. Before this fix the PyQtGraph implementation sorted the legends based on the order in a dict (executing "rqt_plot -e "/pose_sensor/state_out/data[0]:data[1]:data[2]:data[3]" gave order data[2], data[1], data[3], data[0] in the plot).
The second commit enables a title to be set by giving it through -T or --title.
The third commit allows you to set labels using -l of --label and "label1,label2,label3".
