### PR TITLE
rqt_plot: remove warning/debug message when backend not found

### DIFF
--- a/rqt_plot/src/rqt_plot/data_plot/__init__.py
+++ b/rqt_plot/src/rqt_plot/data_plot/__init__.py
@@ -34,25 +34,22 @@
 import numpy
 
 from qt_gui_py_common.simple_settings_dialog import SimpleSettingsDialog
-from python_qt_binding.QtCore import Qt, qDebug, qWarning, Signal
+from python_qt_binding.QtCore import Qt, qWarning, Signal
 from python_qt_binding.QtGui import QColor, QWidget, QHBoxLayout
 
 try:
     from pyqtgraph_data_plot import PyQtGraphDataPlot
 except ImportError:
-    qDebug('[DEBUG] rqt_plot.plot: import of PyQtGraphDataPlot failed (trying other backends)')
     PyQtGraphDataPlot = None
 
 try:
     from mat_data_plot import MatDataPlot
 except ImportError:
-    qDebug('[DEBUG] rqt_plot.plot: import of MatDataPlot failed (trying other backends)')
     MatDataPlot = None
 
 try:
     from qwt_data_plot import QwtDataPlot
 except ImportError:
-    qDebug('[DEBUG] rqt_plot.plot: import of QwtDataPlot failed (trying other backends)')
     QwtDataPlot = None
 
 # separate class for DataPlot exceptions, just so that users can differentiate


### PR DESCRIPTION
New users are confused by the log messages indicating that some of the rqt_plot backends are not found. These debug messages should be removed from the console log, and a message indicating that the backends aren't installed should be added to the backend selection dialog.

I've seen this 3 or 4 times in as many months on ROS answers; the most recent occurrence is: http://answers.ros.org/question/201721/rxplot-not-found/?answer=201784#post-id-201784