### PR TITLE
RQT_BAG: Ensure monotonic clock publishing.

### DIFF
--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -102,7 +102,7 @@ class BagTimeline(QGraphicsScene):
         # the timeline renderer fixes use of black pens and fills, so ensure we fix white here for contrast.
         # otherwise a dark qt theme will default it to black and the frame render pen will be unreadable
         self.setBackgroundBrush(Qt.white)
-        self._timeline_frame = TimelineFrame()
+        self._timeline_frame = TimelineFrame(self)
         self._timeline_frame.setPos(0, 0)
         self.addItem(self._timeline_frame)
 
@@ -364,6 +364,10 @@ class BagTimeline(QGraphicsScene):
             return self._timeline_frame._end_stamp
 
         return entry.time
+
+    def resume(self):
+        if (self._player):
+            self._player.resume()
 
     ### Copy messages to...
 

--- a/rqt_bag/src/rqt_bag/player.py
+++ b/rqt_bag/src/rqt_bag/player.py
@@ -53,6 +53,11 @@ class Player(QObject):
         self._publishers = {}
 
         self._publish_clock = False
+        self._last_clock = rosgraph_msgs.msg.Clock()
+        self._resume = False
+
+    def resume(self):
+        self._resume = True
 
     def is_publishing(self, topic):
         return topic in self._publishing
@@ -123,8 +128,10 @@ class Player(QObject):
         if self._publish_clock:
             time_msg = rosgraph_msgs.msg.Clock()
             time_msg.clock = clock
-            self._publishers[CLOCK_TOPIC].publish(time_msg)
-
+            if self._resume or self._last_clock.clock < time_msg.clock:
+                self._resume = False
+                self._last_clock = time_msg
+                self._publishers[CLOCK_TOPIC].publish(time_msg)
         self._publishers[topic].publish(msg)
 
     def message_cleared(self):

--- a/rqt_bag/src/rqt_bag/timeline_frame.py
+++ b/rqt_bag/src/rqt_bag/timeline_frame.py
@@ -69,9 +69,9 @@ class TimelineFrame(QGraphicsItem):
     Also handles mouse callbacks since they interact closely with the drawn elements
     """
 
-    def __init__(self):
+    def __init__(self, bag_timeline):
         super(TimelineFrame, self).__init__()
-
+        self._bag_timeline = bag_timeline
         self._clicked_pos = None
         self._dragged_pos = None
 
@@ -1019,10 +1019,17 @@ class TimelineFrame(QGraphicsItem):
 
         return (left, right)
 
+    def pause(self):
+        self._paused = True
+
+    def resume(self):
+        self._paused = False
+        self._bag_timeline.resume()
+
     # Mouse event handlers
     def on_middle_down(self, event):
         self._clicked_pos = self._dragged_pos = event.pos()
-        self._paused = True
+        self.pause()
 
     def on_left_down(self, event):
         if self.playhead == None:
@@ -1030,7 +1037,7 @@ class TimelineFrame(QGraphicsItem):
 
         self._clicked_pos = self._dragged_pos = event.pos()
 
-        self._paused = True
+        self.pause()
 
         if event.modifiers() == Qt.ShiftModifier:
             return
@@ -1069,7 +1076,7 @@ class TimelineFrame(QGraphicsItem):
                     self.scene().views()[0].setCursor(QCursor(Qt.ClosedHandCursor))
 
     def on_mouse_up(self, event):
-        self._paused = False
+        self.resume()
 
         if self._selecting_mode in [_SelectionMode.LEFT_MARKED, _SelectionMode.MOVE_LEFT, _SelectionMode.MOVE_RIGHT, _SelectionMode.SHIFTING]:
             if self._selected_left is None:


### PR DESCRIPTION
Due to parallelism issues, a message can be published with a simulated timestamp in the past. This lead to undesired behaviors when using TF for example.

In this PR, when --clock is passed, if the timestamp of the new message to be published is older than the last published clock message, the new clock is dropped but the message is published.