### PR TITLE
Fix compatibility with matplotlib 1.5

### DIFF
--- a/rqt_plot/src/rqt_plot/data_plot/mat_data_plot.py
+++ b/rqt_plot/src/rqt_plot/data_plot/mat_data_plot.py
@@ -59,7 +59,7 @@ except ImportError:
     import thread
     sys.modules['_thread'] = thread
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
 
 import numpy


### PR DESCRIPTION
See: https://github.com/matplotlib/matplotlib/blob/fe6da772defac6177d1f92c9a930498eb71c98f5/doc/api/api_changes.rst#remove-navigationtoolbar2qtagg