### PR TITLE
Add "From nodes" button to rqt_bag record mode like "rosbag record --node"

### DIFF
--- a/rqt_bag/package.xml
+++ b/rqt_bag/package.xml
@@ -23,7 +23,7 @@
   <run_depend>rospy</run_depend>
   <run_depend version_gte="0.2.12">rqt_gui</run_depend>
   <run_depend>rqt_gui_py</run_depend>
-
+  <run_depend>rosnode</run_depend>
   <export>
     <architecture_independent/>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/rqt_bag/src/rqt_bag/node_selection.py
+++ b/rqt_bag/src/rqt_bag/node_selection.py
@@ -1,0 +1,87 @@
+#####################################################################
+# Software License Agreement (BSD License)
+#
+#  Copyright (c) 2016, Ryohei Ueda
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/o2r other materials provided
+#     with the distribution.
+#   * Neither the name of the Willow Garage nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+#  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+#  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+#  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+#  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#####################################################################
+
+import rosgraph
+import rosnode
+from python_qt_binding.QtCore import Qt, Signal
+from python_qt_binding.QtGui import QWidget, QHBoxLayout, QVBoxLayout, QCheckBox, QScrollArea, QPushButton
+
+class NodeSelection(QWidget):
+    def __init__(self, parent):
+        super(NodeSelection, self).__init__()
+        self.parent_widget = parent
+        self.selected_nodes = []
+        self.setWindowTitle("Select the nodes you want to record")
+        self.resize(500, 700)
+        self.area = QScrollArea(self)
+        self.main_widget = QWidget(self.area)
+        self.ok_button = QPushButton("Done", self)
+        self.ok_button.clicked.connect(self.onButtonClicked)
+        self.ok_button.setEnabled(False)
+        self.main_vlayout = QVBoxLayout(self)
+        self.main_vlayout.addWidget(self.area)
+        self.main_vlayout.addWidget(self.ok_button)
+        self.setLayout(self.main_vlayout)
+
+        self.selection_vlayout = QVBoxLayout(self)
+        
+        self.node_list = rosnode.get_node_names()
+        self.node_list.sort()
+        for node in self.node_list:
+            self.addCheckBox(node)
+        self.main_widget.setLayout(self.selection_vlayout)
+        self.show()
+    def addCheckBox(self, node):
+        item = QCheckBox(node, self)
+        item.stateChanged.connect(lambda x: self.updateNode(x,node))
+        self.selection_vlayout.addWidget(item)
+    def updateNode(self, state, node):
+        if state == Qt.Checked:
+            self.selected_nodes.append(node)
+        else:
+            self.selected_nodes.remove(node)
+        if len(self.selected_nodes) > 0:
+            self.ok_button.setEnabled(True)
+        else:
+            self.ok_button.setEnabled(False)
+    def onButtonClicked(self):
+        print self.selected_nodes
+        master = rosgraph.Master('rqt_bag_recorder')
+        state = master.getSystemState()
+        subs = [t for t, l in state[1]
+                if len([node_name for node_name in self.selected_nodes if node_name in l]) > 0]
+        for topic in subs:
+            self.parent_widget.changeTopicCheckState(topic, Qt.Checked)
+            self.parent_widget.updateList(Qt.Checked, topic)
+        self.close()

--- a/rqt_bag/src/rqt_bag/topic_selection.py
+++ b/rqt_bag/src/rqt_bag/topic_selection.py
@@ -34,6 +34,7 @@ import rosgraph
 
 from python_qt_binding.QtCore import Qt, Signal
 from python_qt_binding.QtGui import QWidget, QHBoxLayout, QVBoxLayout, QCheckBox, QScrollArea, QPushButton
+from .node_selection import NodeSelection
 
 class TopicSelection(QWidget):
 
@@ -48,16 +49,18 @@ class TopicSelection(QWidget):
         self.topic_list = []
         self.selected_topics = []
         self.items_list = []
-
         self.area = QScrollArea(self)
         self.main_widget = QWidget(self.area)
         self.ok_button = QPushButton("Record", self)
         self.ok_button.clicked.connect(self.onButtonClicked)
         self.ok_button.setEnabled(False)
-
+        self.from_nodes_button = QPushButton("From Nodes", self)
+        self.from_nodes_button.clicked.connect(self.onFromNodesButtonClicked)
+        
         self.main_vlayout = QVBoxLayout(self)
         self.main_vlayout.addWidget(self.area)
         self.main_vlayout.addWidget(self.ok_button)
+        self.main_vlayout.addWidget(self.from_nodes_button)
         self.setLayout(self.main_vlayout)
 
         self.selection_vlayout = QVBoxLayout(self)
@@ -81,8 +84,12 @@ class TopicSelection(QWidget):
         self.items_list.append(item)
         self.selection_vlayout.addWidget(item)
 
-
-    def updateList(self, state, topic = None):
+    def changeTopicCheckState(self, topic, state):
+        for item in self.items_list:
+            if item.text() == topic:
+                item.setCheckState(state)
+                return
+    def updateList(self, state, topic = None, force_update_state=False):
         if topic is None: # The "All" checkbox was checked / unchecked
             if state == Qt.Checked:
                 self.item_all.setTristate(False)
@@ -110,3 +117,6 @@ class TopicSelection(QWidget):
     def onButtonClicked(self):
         self.close()
         self.recordSettingsSelected.emit((self.item_all.checkState() == Qt.Checked), self.selected_topics)
+    def onFromNodesButtonClicked(self):
+        self.node_selection = NodeSelection(self)
+        


### PR DESCRIPTION
Add node selection window when rqt_bag is used in record mode like
`rosbag record --node`.

User can select node instead of topic to record and rqt_bag automatically 
record the topics which the selected nodes are subscribing.

![select the topics you want to record_013](https://cloud.githubusercontent.com/assets/40454/12542698/e062ed24-c369-11e5-8e74-3a6f7310e5e7.png)
![select the nodes you want to record_014](https://cloud.githubusercontent.com/assets/40454/12542700/e4570262-c369-11e5-8884-1af1814fbdfe.png)
![select the topics you want to record_016](https://cloud.githubusercontent.com/assets/40454/12542703/e59ebe4e-c369-11e5-807a-fbe8ca92c655.png)
