### PR TITLE
rqt_top: fix exception handling

### DIFF
--- a/rqt_top/src/rqt_top/node_info.py
+++ b/rqt_top/src/rqt_top/node_info.py
@@ -102,7 +102,7 @@ class NodeInfo(object):
                         ret = attr()
                 else:
                     ret = attr
-            except AccessDenied:
+            except psutil.AccessDenied:
                 ret = ad_value
             except NotImplementedError:
                 # in case of not implemented functionality (may happen


### PR DESCRIPTION
The code contains:

```python
            try:
                ...
            except AccessDenied:
                ret = ad_value
```
`AccessDenied` is a psutil exception, thus I obtained the following error:

```txt
  File "/opt/ros/indigo/lib/python2.7/site-packages/rqt_top/node_info.py", line 69, in get_all_node_fields
    infos.append(self.as_dict(p, fields + ['cmdline', 'get_memory_info']))
  File "/opt/ros/indigo/lib/python2.7/site-packages/rqt_top/node_info.py", line 105, in as_dict
    except AccessDenied:
NameError: global name 'AccessDenied' is not defined
```

This PR fixes that. I also found incompatibilities with psutil's new API (see #349), but I doubt the error described here is related to that.