### PR TITLE
check alternative matplotplot 1.5 module name

### DIFF
--- a/rqt_plot/src/rqt_plot/data_plot/mat_data_plot.py
+++ b/rqt_plot/src/rqt_plot/data_plot/mat_data_plot.py
@@ -59,7 +59,10 @@ except ImportError:
     import thread
     sys.modules['_thread'] = thread
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+try:
+    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+except ImportError:
+    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
 
 import numpy


### PR DESCRIPTION
Replaces #343.

It uses a more defensive approach in case users are using an older version which doesn't have the new import.