### PR TITLE
rqt_reconfigure: fix accessing attribute superseded in Qt5

### DIFF
--- a/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
@@ -109,9 +109,15 @@ class ParameditWidget(QWidget):
             #    self.vlayout.addWidget(v)
 
         # Add color to alternate the rim of the widget.
-        LayoutUtil.alternate_color(self._dynreconf_clients.itervalues(),
-                                   [self.palette().background().color().lighter(125),
-                                    self.palette().background().color().darker(125)])
+        try:
+            LayoutUtil.alternate_color(self._dynreconf_clients.itervalues(),
+                [self.palette().window().color().lighter(125),
+                self.palette().window().color().darker(125)]) # Qt5
+        except AttributeError:
+            LayoutUtil.alternate_color(self._dynreconf_clients.itervalues(),
+                [self.palette().background().color().lighter(125),
+                self.palette().background().color().darker(125)]) # Qt4
+
 
     def close(self):
         for dc in self._dynreconf_clients:

--- a/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
@@ -111,7 +111,7 @@ class ParameditWidget(QWidget):
         # Add color to alternate the rim of the widget.
         LayoutUtil.alternate_color(self._dynreconf_clients.itervalues(),
             [self.palette().window().color().lighter(125),
-            self.palette().window().color().darker(125)]) # Qt5
+            self.palette().window().color().darker(125)])
 
     def close(self):
         for dc in self._dynreconf_clients:

--- a/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
@@ -109,15 +109,9 @@ class ParameditWidget(QWidget):
             #    self.vlayout.addWidget(v)
 
         # Add color to alternate the rim of the widget.
-        try:
-            LayoutUtil.alternate_color(self._dynreconf_clients.itervalues(),
-                [self.palette().window().color().lighter(125),
-                self.palette().window().color().darker(125)]) # Qt5
-        except AttributeError:
-            LayoutUtil.alternate_color(self._dynreconf_clients.itervalues(),
-                [self.palette().background().color().lighter(125),
-                self.palette().background().color().darker(125)]) # Qt4
-
+        LayoutUtil.alternate_color(self._dynreconf_clients.itervalues(),
+            [self.palette().window().color().lighter(125),
+            self.palette().window().color().darker(125)]) # Qt5
 
     def close(self):
         for dc in self._dynreconf_clients:

--- a/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
@@ -109,9 +109,10 @@ class ParameditWidget(QWidget):
             #    self.vlayout.addWidget(v)
 
         # Add color to alternate the rim of the widget.
-        LayoutUtil.alternate_color(self._dynreconf_clients.itervalues(),
+        LayoutUtil.alternate_color(
+            self._dynreconf_clients.itervalues(),
             [self.palette().window().color().lighter(125),
-            self.palette().window().color().darker(125)])
+             self.palette().window().color().darker(125)])
 
     def close(self):
         for dc in self._dynreconf_clients:


### PR DESCRIPTION
Fixes this issue:
https://github.com/ros-visualization/rqt_common_plugins/issues/369