### PR TITLE
Issue#380 fix crash when toggling thumbnail in rqt_bag

### DIFF
--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
@@ -127,7 +127,7 @@ class ImageTimelineRenderer(TimelineRenderer):
             if width == 1:
                 break
 
-        painter.setPen(QPen(QBrush(Qt.black)))
+        painter.setPen(QPen(Qt.black))
         painter.setBrush(QBrush(Qt.transparent))
         if width == 1:
             painter.drawRect(x, y, thumbnail_x - x, height - thumbnail_gap - 1)


### PR DESCRIPTION
Fixes the crash in image_timeline_renderer.py when toggling thumbnails in rqt_bag.
Seems like the constructor for QPen expects a QColor and not a QBrush.