### PR TITLE
rqt_image_view: use smooth transformation for image scaling

### DIFF
--- a/rqt_image_view/include/rqt_image_view/ratio_layouted_frame.h
+++ b/rqt_image_view/include/rqt_image_view/ratio_layouted_frame.h
@@ -82,6 +82,10 @@ signals:
 
   void mouseLeft(int x, int y);
 
+protected slots:
+
+  void onSmoothImageChanged(bool checked);
+
 protected:
 
   void setAspectRatio(unsigned short width, unsigned short height);
@@ -99,6 +103,7 @@ private:
   QImage qimage_;
   mutable QMutex qimage_mutex_;
 
+  bool smoothImage_;
 };
 
 }

--- a/rqt_image_view/src/rqt_image_view/image_view.cpp
+++ b/rqt_image_view/src/rqt_image_view/image_view.cpp
@@ -98,6 +98,8 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext& context)
   connect(ui_.publish_click_location_check_box, SIGNAL(toggled(bool)), this, SLOT(onMousePublish(bool)));
   connect(ui_.image_frame, SIGNAL(mouseLeft(int, int)), this, SLOT(onMouseLeft(int, int)));
   connect(ui_.publish_click_location_topic_line_edit, SIGNAL(editingFinished()), this, SLOT(onPubTopicChanged()));
+
+  connect(ui_.smooth_image_check_box, SIGNAL(toggled(bool)), ui_.image_frame, SLOT(onSmoothImageChanged(bool)));
 }
 
 void ImageView::shutdownPlugin()

--- a/rqt_image_view/src/rqt_image_view/image_view.ui
+++ b/rqt_image_view/src/rqt_image_view/image_view.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>425</width>
     <height>300</height>
    </rect>
   </property>
@@ -118,6 +118,13 @@
        </property>
        <property name="autoFillBackground">
         <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="smooth_image_check_box">
+       <property name="text">
+        <string>Smooth scaling</string>
        </property>
       </widget>
      </item>

--- a/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
+++ b/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
@@ -139,7 +139,13 @@ void RatioLayoutedFrame::paintEvent(QPaintEvent* event)
     // TODO: check if full draw is really necessary
     //QPaintEvent* paint_event = dynamic_cast<QPaintEvent*>(event);
     //painter.drawImage(paint_event->rect(), qimage_);
-    painter.drawImage(contentsRect(), qimage_);
+    if (contentsRect().width() == qimage_.width()) {
+      painter.drawImage(contentsRect(), qimage_);
+    } else {
+      QImage image = qimage_.scaled(contentsRect().width(), contentsRect().height(),
+                                    Qt::KeepAspectRatio, Qt::SmoothTransformation);
+      painter.drawImage(contentsRect(), image);
+    }
   } else {
     // default image with gradient
     QLinearGradient gradient(0, 0, frameRect().width(), frameRect().height());

--- a/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
+++ b/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
@@ -40,6 +40,7 @@ namespace rqt_image_view {
 RatioLayoutedFrame::RatioLayoutedFrame(QWidget* parent, Qt::WindowFlags flags)
   : QFrame()
   , aspect_ratio_(4, 3)
+  , smoothImage_(false)
 {
   connect(this, SIGNAL(delayed_update()), this, SLOT(update()), Qt::QueuedConnection);
 }
@@ -139,12 +140,16 @@ void RatioLayoutedFrame::paintEvent(QPaintEvent* event)
     // TODO: check if full draw is really necessary
     //QPaintEvent* paint_event = dynamic_cast<QPaintEvent*>(event);
     //painter.drawImage(paint_event->rect(), qimage_);
-    if (contentsRect().width() == qimage_.width()) {
+    if (!smoothImage_) {
       painter.drawImage(contentsRect(), qimage_);
     } else {
-      QImage image = qimage_.scaled(contentsRect().width(), contentsRect().height(),
-                                    Qt::KeepAspectRatio, Qt::SmoothTransformation);
-      painter.drawImage(contentsRect(), image);
+      if (contentsRect().width() == qimage_.width()) {
+        painter.drawImage(contentsRect(), qimage_);
+      } else {
+        QImage image = qimage_.scaled(contentsRect().width(), contentsRect().height(),
+                                      Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        painter.drawImage(contentsRect(), image);
+      }
     }
   } else {
     // default image with gradient
@@ -174,4 +179,9 @@ void RatioLayoutedFrame::mousePressEvent(QMouseEvent * mouseEvent)
   }
   QFrame::mousePressEvent(mouseEvent);
 }
+
+void RatioLayoutedFrame::onSmoothImageChanged(bool checked) {
+  smoothImage_ = checked;
+}
+
 }


### PR DESCRIPTION
Is there a reason for not using the `Qt::SmoothTransformation` when scaling the image inside the `ratio_layouted_frame`? If not I would propose this change. Especially low resolution images e.g. from thermal cameras look much better when scaled.
