### PR TITLE
rqt_console should have auto-resizeable Message column

### DIFF
--- a/rqt_console/src/rqt_console/console_widget.py
+++ b/rqt_console/src/rqt_console/console_widget.py
@@ -94,6 +94,7 @@ class ConsoleWidget(QWidget):
         self._columnwidth = (60, 100, 70, 100, 100, 100, 100)
         for idx, width in enumerate(self._columnwidth):
             self.table_view.horizontalHeader().resizeSection(idx, width)
+        self.table_view.horizontalHeader().setResizeMode(1, QHeaderView.Stretch)
 
         def update_sort_indicator(logical_index, order):
             if logical_index == 0:


### PR DESCRIPTION
Currently, when you launch rqt_console, the Message column is very small (same size as other columns). Messages are nearly always too large for this, which means that each time you launch rqt_console, you need to manually resize the field to be larger. Also, rqt_console usually launches with a window large enough that there is a bunch of wasted space on the right side of the Message table. This is quite frustrating if you are frequently launching rqt_console.

I believe a better default user experience would be to automatically stretch the Message column so that the table fills the space. This way, the Message column is more likely to be wide enough to handle the data present, and if it isnt, the user can very quickly expand the size of the entire window, and the Message column will automatically get larger at the same time.

I propose implementing this by adding this to __init__ in https://github.com/ros-visualization/rqt_common_plugins/blob/master/rqt_console/src/rqt_console/console_widget.py : 
        _self.table_view.horizontalHeader().setResizeMode(1, QHeaderView.Stretch)_

When implemented this way, rqt_console provides an easy, effective user experience by default. You can still manually resize other columns, and Message will shrink to fit, and these sizes will be respected if you expand or shrink the entire window. Also, if you click the "fit columns" button, it will jump to a tight fit on everything, so that still works.

If this proposal is acceptable, I can submit a pull request!

Example of current (no stretch) default behavior (notice wasted space to the right of the Location column):
![rqt_console default](https://cloud.githubusercontent.com/assets/882065/16856840/2d17ba94-49d1-11e6-84b9-17abbc097733.png)


Example of default behavior with stretch added:
![rqt_console with shrink](https://cloud.githubusercontent.com/assets/882065/16856835/2ae21bd4-49d1-11e6-87ff-c3f6e22b35d6.png)


Example of behavior with stretch, after manually expanding the entire window:
![rqt_console with shrink wider](https://cloud.githubusercontent.com/assets/882065/16856830/23bf5254-49d1-11e6-8631-2fdcf2676da7.png)

Example of behavior with stretch, after manually resizing the Severity, Node, and Stamp columns:
![rqt_console shrink manual resize](https://cloud.githubusercontent.com/assets/882065/16856844/30f6c65a-49d1-11e6-9dc8-341100427cbb.png)
