### PR TITLE
Add rqt_common_plugins as runtime dependency for rqt_console

### DIFF
--- a/rqt_console/package.xml
+++ b/rqt_console/package.xml
@@ -17,6 +17,7 @@
   <run_depend version_gte="0.2.19">python_qt_binding</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>rqt_common_plugins</run_depend>
   <run_depend>rqt_gui</run_depend>
   <run_depend>rqt_gui_py</run_depend>
   <run_depend>rqt_logger_level</run_depend>


### PR DESCRIPTION
If I don't have the `rqt-common-plugins` packages installed in the system the rqt_console invocation failed with:

```
RosPluginProvider.load(rqt_console/Console) exception raised in __builtin__.__import__(rqt_console.console, [Console]):
Traceback (most recent call last):
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_gui/ros_plugin_provider.py", line 77, in load
    module = __builtin__.__import__(attributes['module_name'], fromlist=[attributes['class_from_class_type']], level=0)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_console/console.py", line 42, in <module>
    from .console_widget import ConsoleWidget
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_console/console_widget.py", line 43, in <module>
    from rqt_py_common.ini_helper import pack, unpack
ImportError: No module named rqt_py_common.ini_helper
```

Seem like the code is using it, at least in the [console_widget](https://github.com/ros-visualization/rqt_common_plugins/blob/master/rqt_console/src/rqt_console/console_widget.py#L43)