### PR TITLE
[rqt_console] add missing dependency on rqt_py_common

### DIFF
--- a/rqt_console/package.xml
+++ b/rqt_console/package.xml
@@ -20,6 +20,7 @@
   <run_depend>rqt_gui</run_depend>
   <run_depend>rqt_gui_py</run_depend>
   <run_depend>rqt_logger_level</run_depend>
+  <run_depend>rqt_py_common</run_depend>
 
   <export>
     <architecture_independent/>


### PR DESCRIPTION
Fixes #408.