### PR TITLE
use Python 3 compatible syntax

### DIFF
--- a/rqt_bag/src/rqt_bag/__init__.py
+++ b/rqt_bag/src/rqt_bag/__init__.py
@@ -30,8 +30,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import bag_helper
-from plugins.message_view       import MessageView
-from plugins.topic_message_view import TopicMessageView
-from plugins.timeline_renderer  import TimelineRenderer
-from timeline_cache            import TimelineCache
+import rqt_bag.bag_helper
+from rqt_bag.plugins.message_view       import MessageView
+from rqt_bag.plugins.topic_message_view import TopicMessageView
+from rqt_bag.plugins.timeline_renderer  import TimelineRenderer
+from rqt_bag.timeline_cache            import TimelineCache

--- a/rqt_bag/src/rqt_bag/bag_timeline.py
+++ b/rqt_bag/src/rqt_bag/bag_timeline.py
@@ -39,7 +39,7 @@ import threading
 from python_qt_binding.QtCore import Qt, QTimer, qWarning, Signal
 from python_qt_binding.QtWidgets import QGraphicsScene, QMessageBox
 
-import bag_helper
+import rqt_bag.bag_helper
 
 from .timeline_frame import TimelineFrame
 from .message_listener_thread import MessageListenerThread
@@ -673,7 +673,7 @@ class BagTimeline(QGraphicsScene):
     def record_bag(self, filename, all=True, topics=[], regex=False, limit=0):
         try:
             self._recorder = Recorder(filename, bag_lock=self._bag_lock, all=all, topics=topics, regex=regex, limit=limit)
-        except Exception, ex:
+        except Exception as ex:
             qWarning('Error opening bag for recording [%s]: %s' % (filename, str(ex)))
             return
 
@@ -721,7 +721,7 @@ class BagTimeline(QGraphicsScene):
             for listener in self._listeners[topic]:
                 try:
                     listener.timeline_changed()
-                except Exception, ex:
+                except Exception as ex:
                     qWarning('Error calling timeline_changed on %s: %s' % (type(listener), str(ex)))
 
     ### Views / listeners

--- a/rqt_bag/src/rqt_bag/bag_widget.py
+++ b/rqt_bag/src/rqt_bag/bag_widget.py
@@ -42,7 +42,7 @@ from python_qt_binding.QtGui import QIcon
 from python_qt_binding.QtWidgets import QFileDialog, QGraphicsView, QWidget
 
 import rosbag
-import bag_helper
+import rqt_bag.bag_helper
 from .bag_timeline import BagTimeline
 from .topic_selection import TopicSelection
 

--- a/rqt_bag/src/rqt_bag/message_listener_thread.py
+++ b/rqt_bag/src/rqt_bag/message_listener_thread.py
@@ -76,7 +76,7 @@ class MessageListenerThread(threading.Thread):
             try:
                 event = ListenerEvent(bag_msg_data)
                 QCoreApplication.postEvent(self.listener, event)
-            except Exception, ex:
+            except Exception as ex:
                 qWarning('Error notifying listener %s: %s' % (type(self.listener), str(ex)))
 
     def stop(self):

--- a/rqt_bag/src/rqt_bag/recorder.py
+++ b/rqt_bag/src/rqt_bag/recorder.py
@@ -34,7 +34,11 @@
 Recorder subscribes to ROS messages and writes them to a bag file.
 """
 
-import Queue
+from __future__ import print_function
+try:
+    from queue import Queue
+except ImportError:
+    from Queue import Queue
 import re
 import threading
 import time
@@ -78,7 +82,7 @@ class Recorder(object):
         self._limited_topics = set()
         self._failed_topics = set()
         self._last_update = time.time()
-        self._write_queue = Queue.Queue()
+        self._write_queue = Queue()
         self._paused = False
         self._stop_condition = threading.Condition()
         self._stop_flag = False
@@ -159,16 +163,16 @@ class Recorder(object):
                         self._message_count[topic] = 0
 
                         self._subscriber_helpers[topic] = _SubscriberHelper(self, topic, pytype)
-                    except Exception, ex:
-                        print >> sys.stderr, 'Error subscribing to %s (ignoring): %s' % (topic, str(ex))
+                    except Exception as ex:
+                        print('Error subscribing to %s (ignoring): %s' % (topic, str(ex)), file=sys.stderr)
                         self._failed_topics.add(topic)
 
                 # Wait a while
                 self._stop_condition.acquire()
                 self._stop_condition.wait(self._master_check_interval)
 
-        except Exception, ex:
-            print >> sys.stderr, 'Error recording to bag: %s' % str(ex)
+        except Exception as ex:
+            print('Error recording to bag: %s' % str(ex), file=sys.stderr)
 
         # Unsubscribe from all topics
         for topic in list(self._subscriber_helpers.keys()):
@@ -177,8 +181,8 @@ class Recorder(object):
         # Close the bag file so that the index gets written
         try:
             self._bag.close()
-        except Exception, ex:
-            print >> sys.stderr, 'Error closing bag [%s]: %s' % (self._bag.filename, str(ex))
+        except Exception as ex:
+            print('Error closing bag [%s]: %s' % (self._bag.filename, str(ex)))
 
     def _should_subscribe_to(self, topic):
         if self._all:
@@ -232,8 +236,8 @@ class Recorder(object):
                 for listener in self._listeners:
                     listener(topic, m, t)
 
-        except Exception, ex:
-            print >> sys.stderr, 'Error write to bag: %s' % str(ex)
+        except Exception as ex:
+            print('Error write to bag: %s' % str(ex), file=sys.stderr)
 
 
 class _SubscriberHelper(object):

--- a/rqt_bag/src/rqt_bag/timeline_cache.py
+++ b/rqt_bag/src/rqt_bag/timeline_cache.py
@@ -32,7 +32,10 @@
 
 
 import bisect
-import Queue
+try:
+    from queue import Queue
+except ImportError:
+    from Queue import Queue
 import threading
 import time
 
@@ -52,7 +55,7 @@ class TimelineCache(threading.Thread):
         self.last_accessed = {}  # topic -> [(access time, timestamp), ...]
         self.item_access = {}  # topic -> timestamp -> access time
         self.max_cache_size = max_cache_size  # max number of items to cache (per topic)
-        self.queue = Queue.Queue()
+        self.queue = Queue()
         self.setDaemon(True)
         self.start()
 

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_helper.py
@@ -30,8 +30,12 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 import array
-from cStringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 import sys
 
 from PIL import Image
@@ -82,8 +86,8 @@ def imgmsg_to_pil(img_msg, rgba=True):
 
         return pil_img
 
-    except Exception, ex:
-        print >> sys.stderr, 'Can\'t convert image: %s' % ex
+    except Exception as ex:
+        print('Can\'t convert image: %s' % ex, file=sys.stderr)
         return None
 
 

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
@@ -30,6 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 import rospy
 
 # HACK workaround for upstream pillow issue python-pillow/Pillow#400
@@ -45,7 +46,7 @@ from PIL.ImageQt import ImageQt
 
 from rqt_bag import TimelineCache, TimelineRenderer
 
-import image_helper
+import rqt_bag_plugins.image_helper
 
 from python_qt_binding.QtCore import Qt
 from python_qt_binding.QtGui import QBrush, QPen, QPixmap
@@ -161,12 +162,12 @@ class ImageTimelineRenderer(TimelineRenderer):
         # Convert from ROS image to PIL image
         try:
             pil_image = image_helper.imgmsg_to_pil(msg)
-        except Exception, ex:
-            print >> sys.stderr, 'Error loading image on topic %s: %s' % (topic, str(ex))
+        except Exception as ex:
+            print('Error loading image on topic %s: %s' % (topic, str(ex)), file=sys.stderr)
             pil_image = None
 
         if not pil_image:
-            print >> sys.stderr, 'Disabling renderer on %s' % topic
+            print('Disabling renderer on %s' % topic, file=sys.stderr)
             self.timeline.set_renderer_active(topic, False)
             return None, None
 
@@ -179,7 +180,7 @@ class ImageTimelineRenderer(TimelineRenderer):
 
             return msg_stamp, thumbnail
 
-        except Exception, ex:
-            print >> sys.stderr, 'Error loading image on topic %s: %s' % (topic, str(ex))
+        except Exception as ex:
+            print('Error loading image on topic %s: %s' % (topic, str(ex)), file=sys.stderr)
             raise
             return None, None

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
@@ -43,7 +43,7 @@ if (
 from PIL.ImageQt import ImageQt
 
 from rqt_bag import TopicMessageView
-import image_helper
+import rqt_bag_plugins.image_helper
 
 from python_qt_binding.QtGui import QPixmap
 from python_qt_binding.QtWidgets import QGraphicsScene, QGraphicsView

--- a/rqt_dep/src/rqt_dep/dotcode_pack.py
+++ b/rqt_dep/src/rqt_dep/dotcode_pack.py
@@ -221,7 +221,7 @@ class RosPackageGraphDotcodeGenerator:
                     packages_in_stacks.append(package_name)
                     self._generate_package(dotcode_factory, g, package_name)
 
-        for package_name, attributes in self.packages.iteritems():
+        for package_name, attributes in self.packages.items():
             if package_name not in packages_in_stacks:
                 self._generate_package(dotcode_factory, graph, package_name, attributes)
         for name1, name2 in self.edges.keys():

--- a/rqt_dep/src/rqt_dep/ros_pack_graph.py
+++ b/rqt_dep/src/rqt_dep/ros_pack_graph.py
@@ -321,7 +321,7 @@ class RosPackGraph(Plugin):
                         try:
                             service_type = rosservice.get_service_type(service_name)
                             tool_tip += '\n  %s [%s]' % (service_name, service_type)
-                        except rosservice.ROSServiceIOException, e:
+                        except rosservice.ROSServiceIOException as e:
                             tool_tip += '\n  %s' % (e)
                 return tool_tip
             elif item_type == 'topic':
@@ -334,9 +334,9 @@ class RosPackGraph(Plugin):
         for item in self._scene.items():
             self._scene.removeItem(item)
         self._scene.clear()
-        for node_item in self._nodes.itervalues():
+        for node_item in self._nodes.values():
             self._scene.addItem(node_item)
-        for edge_items in self._edges.itervalues():
+        for edge_items in self._edges.values():
             for edge_item in edge_items:
                 edge_item.add_to_scene(self._scene)
 

--- a/rqt_graph/src/rqt_graph/dotcode.py
+++ b/rqt_graph/src/rqt_graph/dotcode.py
@@ -172,7 +172,7 @@ class RosGraphDotcodeGenerator:
         if pub is None and sub in self.edges and topic in self.edges[sub]:
             conns = len(self.edges[sub][topic])
             if conns == 1:
-                pub = next(self.edges[sub][topic].iterkeys())
+                pub = next(self.edges[sub][topic].keys())
             else:
                 penwidth = self._calc_edge_penwidth(sub,topic)
                 color = self._calc_edge_color(sub,topic)

--- a/rqt_graph/src/rqt_graph/ros_graph.py
+++ b/rqt_graph/src/rqt_graph/ros_graph.py
@@ -292,9 +292,9 @@ class RosGraph(Plugin):
                                                             highlight_level=highlight_level,
                                                             same_label_siblings=True)
 
-        for node_item in nodes.itervalues():
+        for node_item in nodes.values():
             self._scene.addItem(node_item)
-        for edge_items in edges.itervalues():
+        for edge_items in edges.values():
             for edge_item in edge_items:
                 edge_item.add_to_scene(self._scene)
 

--- a/rqt_msg/src/rqt_msg/messages_widget.py
+++ b/rqt_msg/src/rqt_msg/messages_widget.py
@@ -203,7 +203,7 @@ class MessagesWidget(QWidget):
 
                 else:
                     raise
-            except rosmsg.ROSMsgException, e:
+            except rosmsg.ROSMsgException as e:
                 QMessageBox.warning(self, self.tr('Warning'),
                                     self.tr('The selected item component ' +
                                             'does not have text to view.'))

--- a/rqt_plot/src/rqt_plot/data_plot/__init__.py
+++ b/rqt_plot/src/rqt_plot/data_plot/__init__.py
@@ -41,17 +41,17 @@ from python_qt_binding.QtWidgets import QWidget, QHBoxLayout
 from rqt_py_common.ini_helper import pack, unpack
 
 try:
-    from pyqtgraph_data_plot import PyQtGraphDataPlot
+    from .pyqtgraph_data_plot import PyQtGraphDataPlot
 except ImportError as e:
     PyQtGraphDataPlot = None
 
 try:
-    from mat_data_plot import MatDataPlot
+    from .mat_data_plot import MatDataPlot
 except ImportError as e:
     MatDataPlot = None
 
 try:
-    from qwt_data_plot import QwtDataPlot
+    from .qwt_data_plot import QwtDataPlot
 except ImportError as e:
     QwtDataPlot = None
 

--- a/rqt_plot/src/rqt_plot/rosplot.py
+++ b/rqt_plot/src/rqt_plot/rosplot.py
@@ -127,7 +127,7 @@ class ROSData(object):
                 else:
                     self.buff_x.append(rospy.get_time() - self.start_time)
                 #self.axes[index].plot(datax, buff_y)
-            except AttributeError, e:
+            except AttributeError as e:
                 self.error = RosPlotException("Invalid topic spec [%s]: %s" % (self.name, str(e)))
         finally:
             self.lock.release()
@@ -197,5 +197,5 @@ def generate_field_evals(fields):
             else:
                 evals.append(_field_eval(f))
         return evals
-    except Exception, e:
+    except Exception as e:
         raise RosPlotException("cannot parse field reference [%s]: %s" % (fields, str(e)))

--- a/rqt_publisher/src/rqt_publisher/publisher.py
+++ b/rqt_publisher/src/rqt_publisher/publisher.py
@@ -194,14 +194,13 @@ class Publisher(Plugin):
                 self._fill_message_slots(publisher_info['message_instance'], publisher_info['topic_name'], publisher_info['expressions'], publisher_info['counter'])
                 try:
                     publisher_info['message_instance']._check_types()
-                except Exception, e:
-                    error_str = str(e)
-                    print 'serialization error:', error_str
+                except Exception as e:
+                    print('serialization error: %s' % e)
                     if old_expression is not None:
                         publisher_info['expressions'][topic_name] = old_expression
                     else:
                         del publisher_info['expressions'][topic_name]
-                    return '%s %s: %s' % (expression, error_prefix, error_str)
+                    return '%s %s: %s' % (expression, error_prefix, e)
                 return expression
             else:
                 return '%s %s evaluating as "%s"' % (expression, error_prefix, slot_type.__name__)
@@ -223,7 +222,7 @@ class Publisher(Plugin):
 
         base_message_type = roslib.message.get_message_class(base_type_str)
         if base_message_type is None:
-            print 'Could not create message of type "%s".' % base_type_str
+            print('Could not create message of type "%s".' % base_type_str)
             return None
 
         if array_size is not None:

--- a/rqt_py_common/src/rqt_py_common/extended_combo_box.py
+++ b/rqt_py_common/src/rqt_py_common/extended_combo_box.py
@@ -59,7 +59,7 @@ class ExtendedComboBox(QComboBox):
         self.setCompleter(self.completer)
 
         # connect signals
-        self.lineEdit().textEdited[unicode].connect(self.filter_model.setFilterFixedString)
+        self.lineEdit().textEdited[str].connect(self.filter_model.setFilterFixedString)
         self.completer.activated.connect(self.on_completer_activated)
         self.setItems.connect(self.onSetItems)
 

--- a/rqt_py_common/src/rqt_py_common/ini_helper.py
+++ b/rqt_py_common/src/rqt_py_common/ini_helper.py
@@ -60,7 +60,14 @@ def unpack(data):
     """
     if data is None or data == '':
         data = []
-    elif isinstance(data, basestring):
+    elif is_string(data):
         data = [data]
     return data
 
+
+def is_string(s):
+    """Check if the argument is a string which works for both Python 2 and 3."""
+    try:
+        return isinstance(s, basestring)
+    except NameError:
+        return isinstance(s, str)

--- a/rqt_py_common/src/rqt_py_common/rosaction.py
+++ b/rqt_py_common/src/rqt_py_common/rosaction.py
@@ -640,7 +640,7 @@ def rosaction_cmd_prototype(args):
     #     if not options.silent:
     #         print(file=sys.stderr, "Invalid package: '%s'"%e)
     #         sys.exit(getattr(os, 'EX_USAGE', 1))
-    except ValueError, e:
+    except ValueError as e:
         if not options.silent:
             sys.stderr.write("Invalid type: '%s'" % e)
             sys.exit(getattr(os, 'EX_USAGE', 1))

--- a/rqt_py_common/src/rqt_py_common/rqt_roscomm_util.py
+++ b/rqt_py_common/src/rqt_py_common/rqt_roscomm_util.py
@@ -79,7 +79,7 @@ class RqtRoscommUtil(object):
                                                                          msg))
         except RLException:
             raise
-        except Exception, e:
+        except Exception as e:
             rospy.logerr("load_parameters: unable to set params " +
                          "(last param was [{}]): {}".format(param, e))
             raise  # re-raise as this is fatal
@@ -87,7 +87,7 @@ class RqtRoscommUtil(object):
         try:
             # multi-call objects are not reusable
             param_server_multi = config.master.get_multi()
-            for param in config.params.itervalues():
+            for param in config.params.values():
                 # suppressing this as it causes too much spam
                 # printlog("setting parameter [%s]"%param.key)
                 param_server_multi.setParam(caller_id, param.key, param.value)
@@ -98,7 +98,7 @@ class RqtRoscommUtil(object):
                                                 "%s" % (msg))
         except RLException:
             raise
-        except Exception, e:
+        except Exception as e:
             print("load_parameters: unable to set params (last param was " +
                   "[%s]): %s" % (param, e))
             raise  # re-raise as this is fatal

--- a/rqt_py_common/test/test_rqt_roscomm_util.py
+++ b/rqt_py_common/test/test_rqt_roscomm_util.py
@@ -61,9 +61,9 @@ class TestRqtRoscommUtil(unittest.TestCase):
         pkg_num_sum = 0
         for pkg in RqtRoscommUtil.iterate_packages('launch'):
             pkg_num_sum += 1
-            print 'pkg={}'.format(pkg)
+            print('pkg={}'.format(pkg))
 
-        print pkg_num_sum
+        print(pkg_num_sum)
         self.assertEqual(pkg_num_sum, self._totalnum_pkg_contains_launch)
 
     def test_list_files(self):
@@ -79,9 +79,9 @@ class TestRqtRoscommUtil(unittest.TestCase):
         files = RqtRoscommUtil.list_files(pkg_name, subdir, file_ext)
         for file in files:
             file_num += 1
-            print 'file={}'.format(file)
+            print('file={}'.format(file))
 
-        print file_num
+        print(file_num)
         self.assertEqual(file_num, _totalnum_launches_pkg_contains)
 
 

--- a/rqt_py_console/src/rqt_py_console/py_console.py
+++ b/rqt_py_console/src/rqt_py_console/py_console.py
@@ -33,7 +33,7 @@
 from python_qt_binding.QtWidgets import QVBoxLayout, QWidget
 from qt_gui.plugin import Plugin
 from qt_gui_py_common.simple_settings_dialog import SimpleSettingsDialog
-from py_console_widget import PyConsoleWidget
+from rqt_py_console.py_console_widget import PyConsoleWidget
 
 try:
     from spyder_console_widget import SpyderConsoleWidget

--- a/rqt_py_console/src/rqt_py_console/py_console_text_edit.py
+++ b/rqt_py_console/src/rqt_py_console/py_console_text_edit.py
@@ -32,7 +32,6 @@
 
 import sys
 from code import InteractiveInterpreter
-from exceptions import SystemExit
 
 from python_qt_binding import QT_BINDING, QT_BINDING_VERSION
 from python_qt_binding.QtCore import Qt, Signal

--- a/rqt_py_console/src/rqt_py_console/py_console_widget.py
+++ b/rqt_py_console/src/rqt_py_console/py_console_widget.py
@@ -35,7 +35,7 @@ import rospkg
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtWidgets import QWidget
-import py_console_text_edit
+from rqt_py_console.py_console_text_edit import PyConsoleTextEdit
 
 
 class PyConsoleWidget(QWidget):
@@ -43,7 +43,7 @@ class PyConsoleWidget(QWidget):
         super(PyConsoleWidget, self).__init__()
         rp = rospkg.RosPack()
         ui_file = os.path.join(rp.get_path('rqt_py_console'), 'resource', 'py_console_widget.ui')
-        loadUi(ui_file, self, {'PyConsoleTextEdit': py_console_text_edit.PyConsoleTextEdit})
+        loadUi(ui_file, self, {'PyConsoleTextEdit': PyConsoleTextEdit})
         self.setObjectName('PyConsoleWidget')
 
         my_locals = {

--- a/rqt_reconfigure/src/rqt_reconfigure/node_selector_widget.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/node_selector_widget.py
@@ -197,7 +197,7 @@ class NodeSelectorWidget(QWidget):
 
         # Determine if it's terminal treenode.
         found_node = False
-        for nodeitem in self._nodeitems.itervalues():
+        for nodeitem in self._nodeitems.values():
             name_nodeitem = nodeitem.data(Qt.DisplayRole)
             name_rosnode_leaf = rosnode_name_selected[
                        rosnode_name_selected.rfind(RqtRosGraph.DELIM_GRN) + 1:]

--- a/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/paramedit_widget.py
@@ -104,13 +104,13 @@ class ParameditWidget(QWidget):
             #LayoutUtil.clear_layout(self.vlayout)
 
             # Re-add the rest of existing items to layout.
-            #for k, v in self._dynreconf_clients.iteritems():
+            #for k, v in self._dynreconf_clients.items():
             #    rospy.loginfo('added to layout k={} v={}'.format(k, v))
             #    self.vlayout.addWidget(v)
 
         # Add color to alternate the rim of the widget.
         LayoutUtil.alternate_color(
-            self._dynreconf_clients.itervalues(),
+            self._dynreconf_clients.values(),
             [self.palette().window().color().lighter(125),
              self.palette().window().color().darker(125)])
 

--- a/rqt_reconfigure/test/test_text_filter.py
+++ b/rqt_reconfigure/test/test_text_filter.py
@@ -58,7 +58,7 @@ class MyTest(unittest.TestCase):
     def test_test_message(self):
         """Testing test_message method."""
         result_regex = self._filter.test_message(self._filtered_text)
-        print 'result_regex={}'.format(result_regex)
+        print('result_regex={}'.format(result_regex))
         self.assertEqual(result_regex,
                          True  # Both _query_text & filtered_text overlaps.
                          )

--- a/rqt_shell/src/rqt_shell/shell.py
+++ b/rqt_shell/src/rqt_shell/shell.py
@@ -34,7 +34,7 @@ from python_qt_binding.QtCore import qVersion
 from qt_gui.plugin import Plugin
 from qt_gui_py_common.simple_settings_dialog import SimpleSettingsDialog
 
-from shell_widget import ShellWidget
+from rqt_shell.shell_widget import ShellWidget
 
 try:
     if qVersion().startswith('5.'):

--- a/rqt_shell/src/rqt_shell/shell_text_edit.py
+++ b/rqt_shell/src/rqt_shell/shell_text_edit.py
@@ -47,5 +47,5 @@ class ShellTextEdit(ConsoleTextEdit):
             out, err = self._pipe.communicate()
             self._stdout.write(out)
             self._stderr.write(err)
-        except Exception, e:
+        except Exception as e:
             self._stderr.write(str(e) + '\n')

--- a/rqt_shell/src/rqt_shell/shell_widget.py
+++ b/rqt_shell/src/rqt_shell/shell_widget.py
@@ -35,7 +35,7 @@ import rospkg
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtWidgets import QWidget
-import shell_text_edit
+from rqt_shell.shell_text_edit import ShellTextEdit
 
 
 class ShellWidget(QWidget):
@@ -43,5 +43,5 @@ class ShellWidget(QWidget):
         super(ShellWidget, self).__init__(parent=parent)
         rp = rospkg.RosPack()
         ui_file = os.path.join(rp.get_path('rqt_shell'), 'resource', 'shell_widget.ui')
-        loadUi(ui_file, self, {'ShellTextEdit': shell_text_edit.ShellTextEdit})
+        loadUi(ui_file, self, {'ShellTextEdit': ShellTextEdit})
         self.setObjectName('ShellWidget')

--- a/rqt_shell/src/rqt_shell/spyder_shell_widget.py
+++ b/rqt_shell/src/rqt_shell/spyder_shell_widget.py
@@ -37,6 +37,14 @@ from spyderlib.widgets.externalshell.baseshell import ExternalShellBase
 from spyderlib.widgets.shell import TerminalWidget
 
 
+def is_string(s):
+    """Check if the argument is a string which works for both Python 2 and 3."""
+    try:
+        return isinstance(s, basestring)
+    except NameError:
+        return isinstance(s, str)
+
+
 class SpyderShellWidget(ExternalShellBase):
     """Spyder Shell Widget: execute a shell in a separate process using spyderlib's ExternalShellBase"""
     SHELL_CLASS = TerminalWidget
@@ -75,7 +83,13 @@ class SpyderShellWidget(ExternalShellBase):
         self.process = QProcess(self)
         self.process.setProcessChannelMode(QProcess.MergedChannels)
 
-        env = [unicode(key_val_pair) for key_val_pair in self.process.systemEnvironment()]
+        env = []
+        for key_val_pair in self.process.systemEnvironment():
+            try:
+                value = unicode(key_val_pair)
+            except NameError:
+                value = str(key_val_pair)
+            env.append(value)
         env.append('TERM=xterm')
         env.append('COLORTERM=gnome-terminal')
         self.process.setEnvironment(env)
@@ -110,8 +124,11 @@ class SpyderShellWidget(ExternalShellBase):
         self.write_output()
 
     def send_to_process(self, text):
-        if not isinstance(text, basestring):
-            text = unicode(text)
+        if not is_string(text):
+            try:
+                text = unicode(text)
+            except NameError:
+                text = str(text)
         if not text.endswith('\n'):
             text += '\n'
         self.process.write(QTextCodec.codecForLocale().fromUnicode(text))

--- a/rqt_shell/src/rqt_shell/xterm_widget.py
+++ b/rqt_shell/src/rqt_shell/xterm_widget.py
@@ -54,7 +54,7 @@ class XTermWidget(QX11EmbedContainer):
         args = ['-into', str(self.winId())]
         self._process.start(self.xterm_cmd, args)
         if self._process.error() == QProcess.FailedToStart:
-            print "failed to execute '%s'" % self.xterm_cmd
+            print("failed to execute '%s'" % self.xterm_cmd)
 
     def shutdown(self):
         self._process.kill()

--- a/rqt_top/src/rqt_top/node_info.py
+++ b/rqt_top/src/rqt_top/node_info.py
@@ -27,7 +27,12 @@
 
 import rosnode
 import rospy
-import xmlrpclib
+try:
+    from xmlrpc.client import ServerProxy
+    from socket import error
+except ImportError:
+    from xmlrpclib import ServerProxy
+    from xmlrpclib.socket import error
 import psutil
 
 ID = '/NODEINFO'
@@ -38,7 +43,7 @@ class NodeInfo(object):
     def get_node_info(self, node_name, skip_cache=False):
         node_api = rosnode.get_api_uri(rospy.get_master(), node_name, skip_cache=skip_cache)
         try:
-            code, msg, pid = xmlrpclib.ServerProxy(node_api[2]).getPid(ID)
+            code, msg, pid = ServerProxy(node_api[2]).getPid(ID)
             if node_name in self.nodes:
                 return self.nodes[node_name]
             else:
@@ -48,7 +53,7 @@ class NodeInfo(object):
                     return p
                 except:
                     return False
-        except xmlrpclib.socket.error:
+        except error:
             if not skip_cache:
                 return self.get_node_info(node_name, skip_cache=True)
             else:

--- a/rqt_top/src/rqt_top/top_plugin.py
+++ b/rqt_top/src/rqt_top/top_plugin.py
@@ -156,7 +156,7 @@ class Top(Plugin):
             twi.setText(col, self.FORMAT_STRS[col] % val)
         self._table_widget.insertTopLevelItem(row, twi)
 
-        for col, (key, func) in self.TOOLTIPS.iteritems():
+        for col, (key, func) in self.TOOLTIPS.items():
             twi.setToolTip(col, func(info[key]))
 
         with self._selected_node_lock:

--- a/rqt_topic/src/rqt_topic/topic_info.py
+++ b/rqt_topic/src/rqt_topic/topic_info.py
@@ -31,7 +31,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import division, with_statement
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from python_qt_binding.QtCore import qWarning
 

--- a/rqt_web/src/rqt_web/web.py
+++ b/rqt_web/src/rqt_web/web.py
@@ -32,7 +32,7 @@
 
 from qt_gui.plugin import Plugin
 
-from web_widget import WebWidget
+from rqt_web.web_widget import WebWidget
 
 
 class Web(Plugin):

--- a/rqt_web/src/rqt_web/web_widget.py
+++ b/rqt_web/src/rqt_web/web_widget.py
@@ -50,6 +50,14 @@ except ImportError:
 from python_qt_binding.QtWidgets import QCompleter, QWidget
 
 
+def is_string(s):
+    """Check if the argument is a string which works for both Python 2 and 3."""
+    try:
+        return isinstance(s, basestring)
+    except NameError:
+        return isinstance(s, str)
+
+
 class WebWidget(QWidget):
     def __init__(self, url=None):
         """
@@ -180,6 +188,6 @@ class WebWidget(QWidget):
         """
         if data is None or data == '':
             data = []
-        elif isinstance(data, basestring):
+        elif is_string(data):
             data = [data]
         return data


### PR DESCRIPTION
While this patch doesn't guarantee that Python 3 works all the way it at last uses Python 3 compatible syntax and addresses obvious problems starting `rqt` and its plugins.