### PR TITLE
fix for qt5 in 16.04 rqt_reconfigure gui bug

### DIFF
--- a/rqt_reconfigure/src/rqt_reconfigure/node_selector_widget.py
+++ b/rqt_reconfigure/src/rqt_reconfigure/node_selector_widget.py
@@ -120,9 +120,8 @@ class NodeSelectorWidget(QWidget):
             self._node_selector_view.header().setResizeMode(
                 0, QHeaderView.ResizeToContents)  # Qt4
         except AttributeError:
-            # TODO QHeaderView.setSectionResizeMode() is currently segfaulting
-            # using Qt 5 with both bindings PyQt as well as PySide
-            pass
+            self._node_selector_view.header().setSectionResizeMode(
+                0, QHeaderView.ResizeToContents)  # Qt5
 
         # Setting slot for when user clicks on QTreeView.
         self.selectionModel = self._node_selector_view.selectionModel()


### PR DESCRIPTION
Our company uses rqt_reconfigure, a Qt5 based GUI software, to dynamically change parameters in the rest of our ROS system during runtime.

This pull request is a fix for qt5 in 16.04 rqt_reconfigure gui issue where node selector widget isn't showing text in node completely, making it very difficult to use to dynamically reconfigure nodes. We have found and fixed the problem ourselves and would like maintainers to apply the patch to ROS Kinetic if they see no issue with it ASAP so others in the community upgrading to 16.04 ROS Kinetic don't run into the same issue. It would also be good so that we can upgrade ROS Kinetic and not build from source and apply the patch manually every time we bring-up a new machine.

Before this change: rqt_reconfigure will resize contents in the node_selector appropriately for Qt4 but not for Qt5 because of a segfaut issue that appears to be fixed now. So In 16.04 ROS Kinectic, rqt_reconfigure does not display text for nodes.

After this change: rqt_reconfigure will resize for Qt5 and now works normally in 16.04 ROS Kinetic.

Testing done: We have a roslaunch that creates some nodes, and I can invoke rqt_reconfigure from that launch file or from src/rqt_reconfigure/param_widget.py, and see all the nodes and click through the tree. Everything resizes as in 14.04 with ROS Jade. No segfaults or crashes.

![working](https://cloud.githubusercontent.com/assets/151264/22520930/0d5d8df8-e86b-11e6-9b58-3314ceccf930.png)
