### PR TITLE
[fix][rqt_bag_plugins] 'image_helper' is not defined" error.

### DIFF
--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
@@ -46,7 +46,7 @@ from PIL.ImageQt import ImageQt
 
 from rqt_bag import TimelineCache, TimelineRenderer
 
-import rqt_bag_plugins.image_helper
+from rqt_bag_plugins import image_helper
 
 from python_qt_binding.QtCore import Qt
 from python_qt_binding.QtGui import QBrush, QPen, QPixmap

--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
+++ b/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
@@ -43,7 +43,7 @@ if (
 from PIL.ImageQt import ImageQt
 
 from rqt_bag import TopicMessageView
-import rqt_bag_plugins.image_helper
+from rqt_bag_plugins import image_helper
 
 from python_qt_binding.QtGui import QPixmap
 from python_qt_binding.QtWidgets import QGraphicsScene, QGraphicsView


### PR DESCRIPTION
Similar to https://github.com/ros-visualization/rqt_common_plugins/issues/424, without this PR I get the following error when I click `Toggle Thumbnail` button after loading a `.bag` file that contains image topics.

```
$ rqt&
$ Loading /home/rosnoodle/Desktop/2017-01-30-15-03-19.bag
Done loading /home/rosnoodele/Desktop/2017-01-30-15-03-19.bag
Error loading image on topic /camera/image_raw: global name 'image_helper' is not defined
Disabling renderer on /camera/image_raw

$ rospack find rqt_bag
/home/rosnoodele/cws_viz/src/ros-visualization/rqt_common_plugins/rqt_bag
$ roscd rqt_bag
$ git log
commit 2c2487a02c83628a14be7bde318d20249167ffdb
Author: Dirk Thomas <dthomas@osrfoundation.org>
Date:   Tue Jan 31 12:35:55 2017 -0800

    fix bag_helper import
:
```

(For testing I used [this bag file](http://opensource-robotics.tokyo.jp/ar_track_alvar_4markers_tork_2017-01-30-15-03-19.bag) that contains images (500+MB though, and URL will likely change soon).