### PR TITLE
[rqt_topic] Fix printing unnecessary errors when subscribed topic stopped coming in.

### DIFF
--- a/rqt_topic/src/rqt_topic/topic_info.py
+++ b/rqt_topic/src/rqt_topic/topic_info.py
@@ -107,6 +107,7 @@ class TopicInfo(ROSTopicHz):
             self.last_message = message
 
     def get_bw(self):
+        '''Update bandwidth'''
         if len(self.timestamps) < 2:
             return None, None, None, None
         current_time = rospy.get_time()
@@ -117,8 +118,10 @@ class TopicInfo(ROSTopicHz):
             total = sum(self.sizes)
             bytes_per_s = total / (current_time - self.timestamps[0])
             mean_size = total / len(self.timestamps)
-            max_size = max(self.sizes)
-            min_size = min(self.sizes)
+            max_size = min_size = None
+            if self.sizes:
+                max_size = max(self.sizes)
+                min_size = min(self.sizes)
             return bytes_per_s, mean_size, min_size, max_size
 
     def get_hz(self):


### PR DESCRIPTION
The following error can keep occurring on the console under certain condition: May not be accurate though, I think this occurs when a topic is subscribed on `rqt_topic`, received but later no new messages arriving.

```
Traceback (most recent call last):
  File "/home/rosnoodle/cws_viz/src/ros-visualization/rqt_common_plugins/rqt_topic/src/rqt_topic/topic_widget.py", line 193, in refresh_topics
    self._update_topics_data()
  File "/home/rosnoodle/cws_viz/src/ros-visualization/rqt_common_plugins/rqt_topic/src/rqt_topic/topic_widget.py", line 204, in _update_topics_data
    bytes_per_s, _, _, _ = topic_info.get_bw()
  File "/home/rosnoodle/cws_viz/src/ros-visualization/rqt_common_plugins/rqt_topic/src/rqt_topic/topic_info.py", line 120, in get_bw
    max_size = max(self.sizes)
ValueError: max() arg is an empty sequence
```

This error doesn't affect GUI usage AFAIK but because the error happens very frequently, console gets messy and this could give wrong impression that there are errors in ROS network happening (which is false. It's just GUI).

Tested on Indigo.