### PR TITLE
[rqt_image_view]Added context menu to hide the upper menu bar

### DIFF
--- a/rqt_image_view/include/rqt_image_view/image_view.h
+++ b/rqt_image_view/include/rqt_image_view/image_view.h
@@ -85,12 +85,10 @@ protected:
   virtual QSet<QString> getTopics(const QSet<QString>& message_types, const QSet<QString>& message_sub_types, const QList<QString>& transports);
 
   virtual void selectTopic(const QString& topic);
-  virtual void selectOverlayTopic(const QString& topic);
 
 protected slots:
 
   virtual void onTopicChanged(int index);
-  virtual void onOverlayChanged(int index);
 
   virtual void onZoom1(bool checked);
 
@@ -108,18 +106,15 @@ protected slots:
 protected:
 
   virtual void callbackImage(const sensor_msgs::Image::ConstPtr& msg);
-  virtual void callbackOverlay(const sensor_msgs::Image::ConstPtr& msg);
 
   Ui::ImageViewWidget ui_;
 
   QWidget* widget_;
 
   image_transport::Subscriber subscriber_;
-  image_transport::Subscriber overlay_subscriber_;
 
   cv::Mat conversion_mat_;
 
-  QImage overlayImage;
 
 private:
 

--- a/rqt_image_view/include/rqt_image_view/image_view.h
+++ b/rqt_image_view/include/rqt_image_view/image_view.h
@@ -48,6 +48,8 @@
 #include <QString>
 #include <QSize>
 #include <QWidget>
+#include <QAction>
+#include <QImage>
 
 #include <vector>
 
@@ -83,10 +85,12 @@ protected:
   virtual QSet<QString> getTopics(const QSet<QString>& message_types, const QSet<QString>& message_sub_types, const QList<QString>& transports);
 
   virtual void selectTopic(const QString& topic);
+  virtual void selectOverlayTopic(const QString& topic);
 
 protected slots:
 
   virtual void onTopicChanged(int index);
+  virtual void onOverlayChanged(int index);
 
   virtual void onZoom1(bool checked);
 
@@ -99,18 +103,23 @@ protected slots:
   virtual void onMouseLeft(int x, int y);
 
   virtual void onPubTopicChanged();
+  virtual void set_controls_visiblity(bool show);
 
 protected:
 
   virtual void callbackImage(const sensor_msgs::Image::ConstPtr& msg);
+  virtual void callbackOverlay(const sensor_msgs::Image::ConstPtr& msg);
 
   Ui::ImageViewWidget ui_;
 
   QWidget* widget_;
 
   image_transport::Subscriber subscriber_;
+  image_transport::Subscriber overlay_subscriber_;
 
   cv::Mat conversion_mat_;
+
+  QImage overlayImage;
 
 private:
 
@@ -119,6 +128,7 @@ private:
 
   bool pub_topic_custom_;
 
+  QAction *tools_hide_action;
 };
 
 }

--- a/rqt_image_view/include/rqt_image_view/image_view.h
+++ b/rqt_image_view/include/rqt_image_view/image_view.h
@@ -101,7 +101,7 @@ protected slots:
   virtual void onMouseLeft(int x, int y);
 
   virtual void onPubTopicChanged();
-  virtual void set_controls_visiblity(bool show);
+  virtual void setControlsVisiblity(bool show);
 
 protected:
 

--- a/rqt_image_view/include/rqt_image_view/image_view.h
+++ b/rqt_image_view/include/rqt_image_view/image_view.h
@@ -123,7 +123,7 @@ private:
 
   bool pub_topic_custom_;
 
-  QAction *tools_hide_action;
+  QAction *tools_hide_action_;
 };
 
 }

--- a/rqt_image_view/include/rqt_image_view/image_view.h
+++ b/rqt_image_view/include/rqt_image_view/image_view.h
@@ -115,7 +115,6 @@ protected:
 
   cv::Mat conversion_mat_;
 
-
 private:
 
   QString arg_topic_name;

--- a/rqt_image_view/src/rqt_image_view/image_view.cpp
+++ b/rqt_image_view/src/rqt_image_view/image_view.cpp
@@ -67,15 +67,12 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext& context)
   ui_.topics_combo_box->setCurrentIndex(ui_.topics_combo_box->findText(""));
   connect(ui_.topics_combo_box, SIGNAL(currentIndexChanged(int)), this, SLOT(onTopicChanged(int)));
 
-  ui_.refresh_topics_push_button->setIcon(QIcon::fromTheme("view-refresh"));
   connect(ui_.refresh_topics_push_button, SIGNAL(pressed()), this, SLOT(updateTopicList()));
 
-  ui_.zoom_1_push_button->setIcon(QIcon::fromTheme("zoom-original"));
   connect(ui_.zoom_1_push_button, SIGNAL(toggled(bool)), this, SLOT(onZoom1(bool)));
 
   connect(ui_.dynamic_range_check_box, SIGNAL(toggled(bool)), this, SLOT(onDynamicRange(bool)));
 
-  ui_.save_as_image_push_button->setIcon(QIcon::fromTheme("image-x-generic"));
   connect(ui_.save_as_image_push_button, SIGNAL(pressed()), this, SLOT(saveImage()));
 
   // set topic name if passed in as argument
@@ -101,6 +98,11 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext& context)
   connect(ui_.publish_click_location_topic_line_edit, SIGNAL(editingFinished()), this, SLOT(onPubTopicChanged()));
 
   connect(ui_.smooth_image_check_box, SIGNAL(toggled(bool)), ui_.image_frame, SLOT(onSmoothImageChanged(bool)));
+
+  tools_hide_action = new QAction(tr("Hide toolbar"), this);
+  tools_hide_action->setCheckable(true);
+  ui_.image_frame->addAction(tools_hide_action);
+  connect(tools_hide_action, SIGNAL(toggled(bool)), this, SLOT(set_controls_visiblity(bool)));
 }
 
 void ImageView::shutdownPlugin()
@@ -119,6 +121,7 @@ void ImageView::saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::
   instance_settings.setValue("max_range", ui_.max_range_double_spin_box->value());
   instance_settings.setValue("publish_click_location", ui_.publish_click_location_check_box->isChecked());
   instance_settings.setValue("mouse_pub_topic", ui_.publish_click_location_topic_line_edit->text());
+  instance_settings.setValue("controls_hidden", tools_hide_action->isChecked());
 }
 
 void ImageView::restoreSettings(const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings)
@@ -149,6 +152,9 @@ void ImageView::restoreSettings(const qt_gui_cpp::Settings& plugin_settings, con
 
   QString pub_topic = instance_settings.value("mouse_pub_topic", "").toString();
   ui_.publish_click_location_topic_line_edit->setText(pub_topic);
+
+  bool controls_hidden = instance_settings.value("controls_hidden", false).toBool();
+  tools_hide_action->setChecked(controls_hidden);
 }
 
 void ImageView::updateTopicList()
@@ -428,6 +434,11 @@ void ImageView::callbackImage(const sensor_msgs::Image::ConstPtr& msg)
     ui_.zoom_1_push_button->setEnabled(true);
     onZoom1(ui_.zoom_1_push_button->isChecked());
   }
+}
+
+void rqt_image_view::ImageView::set_controls_visiblity(bool hide)
+{
+  ui_.controlsWidget->setVisible(!hide);
 }
 
 }

--- a/rqt_image_view/src/rqt_image_view/image_view.cpp
+++ b/rqt_image_view/src/rqt_image_view/image_view.cpp
@@ -99,10 +99,10 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext& context)
 
   connect(ui_.smooth_image_check_box, SIGNAL(toggled(bool)), ui_.image_frame, SLOT(onSmoothImageChanged(bool)));
 
-  tools_hide_action = new QAction(tr("Hide toolbar"), this);
-  tools_hide_action->setCheckable(true);
-  ui_.image_frame->addAction(tools_hide_action);
-  connect(tools_hide_action, SIGNAL(toggled(bool)), this, SLOT(setControlsVisiblity(bool)));
+  tools_hide_action_ = new QAction(tr("Hide toolbar"), this);
+  tools_hide_action_->setCheckable(true);
+  ui_.image_frame->addAction(tools_hide_action_);
+  connect(tools_hide_action_, SIGNAL(toggled(bool)), this, SLOT(setControlsVisiblity(bool)));
 }
 
 void ImageView::shutdownPlugin()
@@ -121,7 +121,7 @@ void ImageView::saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::
   instance_settings.setValue("max_range", ui_.max_range_double_spin_box->value());
   instance_settings.setValue("publish_click_location", ui_.publish_click_location_check_box->isChecked());
   instance_settings.setValue("mouse_pub_topic", ui_.publish_click_location_topic_line_edit->text());
-  instance_settings.setValue("controls_hidden", tools_hide_action->isChecked());
+  instance_settings.setValue("controls_hidden", tools_hide_action_->isChecked());
 }
 
 void ImageView::restoreSettings(const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings)
@@ -154,7 +154,7 @@ void ImageView::restoreSettings(const qt_gui_cpp::Settings& plugin_settings, con
   ui_.publish_click_location_topic_line_edit->setText(pub_topic);
 
   bool controls_hidden = instance_settings.value("controls_hidden", false).toBool();
-  tools_hide_action->setChecked(controls_hidden);
+  tools_hide_action_->setChecked(controls_hidden);
 }
 
 void ImageView::updateTopicList()

--- a/rqt_image_view/src/rqt_image_view/image_view.cpp
+++ b/rqt_image_view/src/rqt_image_view/image_view.cpp
@@ -102,7 +102,7 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext& context)
   tools_hide_action = new QAction(tr("Hide toolbar"), this);
   tools_hide_action->setCheckable(true);
   ui_.image_frame->addAction(tools_hide_action);
-  connect(tools_hide_action, SIGNAL(toggled(bool)), this, SLOT(set_controls_visiblity(bool)));
+  connect(tools_hide_action, SIGNAL(toggled(bool)), this, SLOT(setControlsVisiblity(bool)));
 }
 
 void ImageView::shutdownPlugin()
@@ -436,7 +436,7 @@ void ImageView::callbackImage(const sensor_msgs::Image::ConstPtr& msg)
   }
 }
 
-void rqt_image_view::ImageView::set_controls_visiblity(bool hide)
+void rqt_image_view::ImageView::setControlsVisiblity(bool hide)
 {
   ui_.controlsWidget->setVisible(!hide);
 }

--- a/rqt_image_view/src/rqt_image_view/image_view.cpp
+++ b/rqt_image_view/src/rqt_image_view/image_view.cpp
@@ -67,12 +67,15 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext& context)
   ui_.topics_combo_box->setCurrentIndex(ui_.topics_combo_box->findText(""));
   connect(ui_.topics_combo_box, SIGNAL(currentIndexChanged(int)), this, SLOT(onTopicChanged(int)));
 
+  ui_.refresh_topics_push_button->setIcon(QIcon::fromTheme("view-refresh"));
   connect(ui_.refresh_topics_push_button, SIGNAL(pressed()), this, SLOT(updateTopicList()));
 
+  ui_.zoom_1_push_button->setIcon(QIcon::fromTheme("zoom-original"));
   connect(ui_.zoom_1_push_button, SIGNAL(toggled(bool)), this, SLOT(onZoom1(bool)));
 
   connect(ui_.dynamic_range_check_box, SIGNAL(toggled(bool)), this, SLOT(onDynamicRange(bool)));
 
+  ui_.save_as_image_push_button->setIcon(QIcon::fromTheme("image-x-generic"));
   connect(ui_.save_as_image_push_button, SIGNAL(pressed()), this, SLOT(saveImage()));
 
   // set topic name if passed in as argument

--- a/rqt_image_view/src/rqt_image_view/image_view.ui
+++ b/rqt_image_view/src/rqt_image_view/image_view.ui
@@ -19,114 +19,129 @@
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
    <item>
     <widget class="QWidget" name="controlsWidget" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0,0,1">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QComboBox" name="topics_combo_box">
-        <property name="sizeAdjustPolicy">
-         <enum>QComboBox::AdjustToContents</enum>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QComboBox" name="topics_combo_box">
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="refresh_topics_push_button">
+          <property name="icon">
+           <iconset theme="view-refresh">
+            <normaloff/>
+           </iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="zoom_1_push_button">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="icon">
+           <iconset theme="zoom-original">
+            <normaloff/>
+           </iconset>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="dynamic_range_check_box">
+          <property name="toolTip">
+           <string>Dynamic depth range</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="max_range_double_spin_box">
+          <property name="toolTip">
+           <string>Max depth</string>
+          </property>
+          <property name="suffix">
+           <string>m</string>
+          </property>
+          <property name="minimum">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>100.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>10.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="save_as_image_push_button">
+          <property name="toolTip">
+           <string>Save as image</string>
+          </property>
+          <property name="icon">
+           <iconset theme="image-x-generic">
+            <normaloff/>
+           </iconset>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>16</width>
+            <height>16</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="smooth_image_check_box">
+          <property name="toolTip">
+           <string>Dynamic depth range</string>
+          </property>
+          <property name="text">
+           <string>Smooth scaling</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
-       <widget class="QPushButton" name="refresh_topics_push_button">
-        <property name="icon">
-         <iconset theme="view-refresh">
-          <normaloff/>
-         </iconset>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="zoom_1_push_button">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="icon">
-         <iconset theme="zoom-original">
-          <normaloff/>
-         </iconset>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="dynamic_range_check_box">
-        <property name="toolTip">
-         <string>Dynamic depth range</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QDoubleSpinBox" name="max_range_double_spin_box">
-        <property name="toolTip">
-         <string>Max depth</string>
-        </property>
-        <property name="suffix">
-         <string>m</string>
-        </property>
-        <property name="minimum">
-         <double>0.010000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>100.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>10.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="save_as_image_push_button">
-        <property name="toolTip">
-         <string>Save as image</string>
-        </property>
-        <property name="icon">
-         <iconset theme="image-x-generic">
-          <normaloff/>
-         </iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>16</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="smooth_image_check_box">
-        <property name="text">
-         <string>Smooth image</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="publish_click_location_check_box">
-        <property name="text">
-         <string>Publish click:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLineEdit" name="publish_click_location_topic_line_edit"/>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QCheckBox" name="publish_click_location_check_box">
+          <property name="text">
+           <string>Publish click location</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="publish_click_location_topic_line_edit">
+          <property name="toolTip">
+           <string>Click location topic (leave empty for auto-naming)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/rqt_image_view/src/rqt_image_view/image_view.ui
+++ b/rqt_image_view/src/rqt_image_view/image_view.ui
@@ -19,7 +19,7 @@
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
    <item>
     <widget class="QWidget" name="controlsWidget" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0,0,0,1">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0,0,1">
       <item>
        <widget class="QComboBox" name="topics_combo_box">
         <property name="sizeAdjustPolicy">
@@ -99,40 +99,21 @@
        </widget>
       </item>
       <item>
-       <widget class="QComboBox" name="overlay_combo_box"/>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="display_latency_check_box">
-        <property name="toolTip">
-         <string>If checked a bar will be displayed on the top of the image which lenght is corresponds to the time difference between the displaying of the image and the timestamp in the header of the image</string>
-        </property>
+       <widget class="QCheckBox" name="smooth_image_check_box">
         <property name="text">
-         <string>Display latency</string>
+         <string>Smooth image</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="max_latency_label">
+       <widget class="QCheckBox" name="publish_click_location_check_box">
         <property name="text">
-         <string>Max:</string>
+         <string>Publish click:</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QSpinBox" name="full_scale_latency_spin_box">
-        <property name="toolTip">
-         <string>If the latency is greater than the value set here the display bar will be shown in the whole width of the image.</string>
-        </property>
-        <property name="suffix">
-         <string> ms</string>
-        </property>
-        <property name="maximum">
-         <number>99999</number>
-        </property>
-        <property name="value">
-         <number>1000</number>
-        </property>
-       </widget>
+       <widget class="QLineEdit" name="publish_click_location_topic_line_edit"/>
       </item>
       <item>
        <spacer name="horizontalSpacer">
@@ -222,38 +203,5 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>display_latency_check_box</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>max_latency_label</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>482</x>
-     <y>32</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>539</x>
-     <y>31</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>display_latency_check_box</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>full_scale_latency_spin_box</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>409</x>
-     <y>31</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>594</x>
-     <y>26</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/rqt_image_view/src/rqt_image_view/image_view.ui
+++ b/rqt_image_view/src/rqt_image_view/image_view.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>799</width>
-    <height>409</height>
+    <width>425</width>
+    <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,8 +33,7 @@
          <widget class="QPushButton" name="refresh_topics_push_button">
           <property name="icon">
            <iconset theme="view-refresh">
-            <normaloff/>
-           </iconset>
+            <normaloff>.</normaloff>.</iconset>
           </property>
          </widget>
         </item>
@@ -45,8 +44,7 @@
           </property>
           <property name="icon">
            <iconset theme="zoom-original">
-            <normaloff/>
-           </iconset>
+            <normaloff>.</normaloff>.</iconset>
           </property>
           <property name="checkable">
            <bool>true</bool>
@@ -89,8 +87,7 @@
           </property>
           <property name="icon">
            <iconset theme="image-x-generic">
-            <normaloff/>
-           </iconset>
+            <normaloff>.</normaloff>.</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -101,14 +98,17 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="smooth_image_check_box">
-          <property name="toolTip">
-           <string>Dynamic depth range</string>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-          <property name="text">
-           <string>Smooth scaling</string>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
           </property>
-         </widget>
+         </spacer>
         </item>
        </layout>
       </item>
@@ -117,7 +117,7 @@
         <item>
          <widget class="QCheckBox" name="publish_click_location_check_box">
           <property name="text">
-           <string>Publish click location</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -125,6 +125,16 @@
          <widget class="QLineEdit" name="publish_click_location_topic_line_edit">
           <property name="toolTip">
            <string>Click location topic (leave empty for auto-naming)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="smooth_image_check_box">
+          <property name="toolTip">
+           <string>Dynamic depth range</string>
+          </property>
+          <property name="text">
+           <string>Smooth scaling</string>
           </property>
          </widget>
         </item>

--- a/rqt_image_view/src/rqt_image_view/image_view.ui
+++ b/rqt_image_view/src/rqt_image_view/image_view.ui
@@ -9,139 +9,146 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>425</width>
-    <height>300</height>
+    <width>799</width>
+    <height>409</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Image View</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,1">
-     <item>
-      <widget class="QComboBox" name="topics_combo_box">
-       <property name="sizeAdjustPolicy">
-        <enum>QComboBox::AdjustToContents</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="refresh_topics_push_button"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="zoom_1_push_button">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="dynamic_range_check_box">
-       <property name="toolTip">
-        <string>Dynamic depth range</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDoubleSpinBox" name="max_range_double_spin_box">
-       <property name="toolTip">
-        <string>Max depth</string>
-       </property>
-       <property name="suffix">
-        <string>m</string>
-       </property>
-       <property name="minimum">
-        <double>0.010000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>100.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>10.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="save_as_image_push_button">
-       <property name="toolTip">
-        <string>Save as image</string>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>16</width>
-         <height>16</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QCheckBox" name="publish_click_location_check_box">
-       <property name="toolTip">
-        <string>Publish click location</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="publish_click_location_topic_line_edit">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="toolTip">
-        <string>Click location topic (leave empty for auto-naming)</string>
-       </property>
-       <property name="autoFillBackground">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="smooth_image_check_box">
-       <property name="text">
-        <string>Smooth scaling</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    <widget class="QWidget" name="controlsWidget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0,0,0,1">
+      <item>
+       <widget class="QComboBox" name="topics_combo_box">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="refresh_topics_push_button">
+        <property name="icon">
+         <iconset theme="view-refresh">
+          <normaloff/>
+         </iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="zoom_1_push_button">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="icon">
+         <iconset theme="zoom-original">
+          <normaloff/>
+         </iconset>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="dynamic_range_check_box">
+        <property name="toolTip">
+         <string>Dynamic depth range</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDoubleSpinBox" name="max_range_double_spin_box">
+        <property name="toolTip">
+         <string>Max depth</string>
+        </property>
+        <property name="suffix">
+         <string>m</string>
+        </property>
+        <property name="minimum">
+         <double>0.010000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>100.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>10.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="save_as_image_push_button">
+        <property name="toolTip">
+         <string>Save as image</string>
+        </property>
+        <property name="icon">
+         <iconset theme="image-x-generic">
+          <normaloff/>
+         </iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="overlay_combo_box"/>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="display_latency_check_box">
+        <property name="toolTip">
+         <string>If checked a bar will be displayed on the top of the image which lenght is corresponds to the time difference between the displaying of the image and the timestamp in the header of the image</string>
+        </property>
+        <property name="text">
+         <string>Display latency</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="max_latency_label">
+        <property name="text">
+         <string>Max:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="full_scale_latency_spin_box">
+        <property name="toolTip">
+         <string>If the latency is greater than the value set here the display bar will be shown in the whole width of the image.</string>
+        </property>
+        <property name="suffix">
+         <string> ms</string>
+        </property>
+        <property name="maximum">
+         <number>99999</number>
+        </property>
+        <property name="value">
+         <number>1000</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0">
@@ -161,6 +168,9 @@
          <width>80</width>
          <height>60</height>
         </size>
+       </property>
+       <property name="contextMenuPolicy">
+        <enum>Qt::ActionsContextMenu</enum>
        </property>
        <property name="frameShape">
         <enum>QFrame::Box</enum>
@@ -212,5 +222,38 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>display_latency_check_box</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>max_latency_label</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>482</x>
+     <y>32</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>539</x>
+     <y>31</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>display_latency_check_box</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>full_scale_latency_spin_box</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>409</x>
+     <y>31</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>594</x>
+     <y>26</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
This patch adds a simple right mouse button hide menu option to the rqt_image_view:

![kep](https://cloud.githubusercontent.com/assets/1609182/22866237/3fb8a43e-f173-11e6-90f5-54fa93ff0947.png)

If this option is unchecked (by default) the whole toolbar is visible:
![kep](https://cloud.githubusercontent.com/assets/1609182/22866245/65ab1ad2-f173-11e6-9d94-ee3958e53815.png)

When checked the toolbar is hidden:
![kep](https://cloud.githubusercontent.com/assets/1609182/22866252/78abca96-f173-11e6-991e-4e6f2d594e14.png)

...leaving more space on the rqt's ui for another widgets.

The toolbar's visibility state is saved to the settings.

This PR should be the beginning of a PR series what would the following features to rqt:
- Overlaying an ARGB image to the image view
- Display image latency
- Image rotation
- Pausable streaming

The patches above will add significant amount controls to the menu which is better to be hidden.

I have also moved the button icons to the ui file (from C++ code), because it makes more straigthforward to edit them with Qt designer. 