### PR TITLE
[rqt_image_view] Add a scroll area

### DIFF
--- a/rqt_image_view/src/rqt_image_view/image_view.cpp
+++ b/rqt_image_view/src/rqt_image_view/image_view.cpp
@@ -293,9 +293,6 @@ void ImageView::onZoom1(bool checked)
       return;
     }
     ui_.image_frame->setInnerFrameFixedSize(ui_.image_frame->getImage().size());
-    widget_->resize(ui_.image_frame->size());
-    widget_->setMinimumSize(widget_->sizeHint());
-    widget_->setMaximumSize(widget_->sizeHint());
   } else {
     ui_.image_frame->setInnerFrameMinimumSize(QSize(80, 60));
     ui_.image_frame->setMaximumSize(QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));

--- a/rqt_image_view/src/rqt_image_view/image_view.ui
+++ b/rqt_image_view/src/rqt_image_view/image_view.ui
@@ -149,57 +149,53 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="rqt_image_view::RatioLayoutedFrame" name="image_frame">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      <widget class="QScrollArea" name="scrollArea">
+       <property name="widgetResizable">
+        <bool>true</bool>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>80</width>
-         <height>60</height>
-        </size>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::Box</enum>
-       </property>
-       <property name="lineWidth">
-        <number>1</number>
-       </property>
+       <widget class="QWidget" name="scrollAreaWidgetContents">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>767</width>
+          <height>650</height>
+         </rect>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
+           <widget class="rqt_image_view::RatioLayoutedFrame" name="image_frame">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>60</height>
+             </size>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::Box</enum>
+            </property>
+            <property name="lineWidth">
+             <number>1</number>
+            </property>
+           </widget>
+          </item>
+        </layout>
+       </widget>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
     </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
When selecting a 1-to-1 pixel view, the previous implementation resized the
window to the full image size. This is inconvenient for images much larger than
the screen resolution. This patch places the RatioLayoutedFrame in a ScrollArea
so the window still fits on the screen and the user can pan on the full image.