### PR TITLE
Fix crash of rqt_graph when enable_statistics == true, fixes #428

### DIFF
--- a/rqt_graph/src/rqt_graph/dotcode.py
+++ b/rqt_graph/src/rqt_graph/dotcode.py
@@ -172,7 +172,7 @@ class RosGraphDotcodeGenerator:
         if pub is None and sub in self.edges and topic in self.edges[sub]:
             conns = len(self.edges[sub][topic])
             if conns == 1:
-                pub = next(self.edges[sub][topic].keys())
+                pub = self.edges[sub][topic].keys()[0]
             else:
                 penwidth = self._calc_edge_penwidth(sub,topic)
                 color = self._calc_edge_color(sub,topic)


### PR DESCRIPTION
`self.edges[sub][topic].keys()` returns a list, while `next()` expects an iterator, which leads to a `TypeError: list object is not an iterator` exception. Fixed by taking element 0 of the key list instead.