### PR TITLE
Convenience launch file for rqt_bag

### DIFF
--- a/rqt_bag/launch/rqt_bag.launch
+++ b/rqt_bag/launch/rqt_bag.launch
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="bag" default="" doc="bag file to load"/>
+  <node name="rqt_bag" pkg="rqt_bag" type="rqt_bag"
+    args="$(arg bag)"/>
+</launch>


### PR DESCRIPTION
It's useful to have a simple launch wrapper for rqt_bag so that it is automatic to get a roscore running if there isn't one running already - for example getting rqt_bag associated with *.bag file in Ubuntu: http://answers.ros.org/question/256044/open-bags-in-rqt_bag-in-by-clicking-on-one-in-ubuntu/

This a workaround for #238 

I notice there are no other launch files in here other than test/test.launch, I couldn't say if adding this one implies every plugin here ought to have one like this.