### PR TITLE
[rqt_image_view] Don't shrink the image when the aspect ratio changes

### DIFF
--- a/rqt_image_view/include/rqt_image_view/ratio_layouted_frame.h
+++ b/rqt_image_view/include/rqt_image_view/ratio_layouted_frame.h
@@ -71,6 +71,7 @@ public:
   void resizeToFitAspectRatio();
 
   void setOuterLayout(QHBoxLayout* outer_layout);
+
   void setInnerFrameMinimumSize(const QSize& size);
 
   void setInnerFrameMaximumSize(const QSize& size);
@@ -100,6 +101,7 @@ private:
   void mousePressEvent(QMouseEvent * mouseEvent);
 
   QHBoxLayout* outer_layout_;
+
   QSize aspect_ratio_;
 
   QImage qimage_;

--- a/rqt_image_view/include/rqt_image_view/ratio_layouted_frame.h
+++ b/rqt_image_view/include/rqt_image_view/ratio_layouted_frame.h
@@ -70,6 +70,7 @@ public:
 
   void resizeToFitAspectRatio();
 
+  void setOuterLayout(QHBoxLayout* outer_layout);
   void setInnerFrameMinimumSize(const QSize& size);
 
   void setInnerFrameMaximumSize(const QSize& size);
@@ -98,6 +99,7 @@ private:
 
   void mousePressEvent(QMouseEvent * mouseEvent);
 
+  QHBoxLayout* outer_layout_;
   QSize aspect_ratio_;
 
   QImage qimage_;

--- a/rqt_image_view/src/rqt_image_view/image_view.cpp
+++ b/rqt_image_view/src/rqt_image_view/image_view.cpp
@@ -94,6 +94,8 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext& context)
   }
   pub_topic_custom_ = false;
 
+  ui_.image_frame->setOuterLayout(ui_.image_layout);
+
   QRegExp rx("([a-zA-Z/][a-zA-Z0-9_/]*)?"); //see http://www.ros.org/wiki/ROS/Concepts#Names.Valid_Names (but also accept an empty field)
   ui_.publish_click_location_topic_line_edit->setValidator(new QRegExpValidator(rx, this));
   connect(ui_.publish_click_location_check_box, SIGNAL(toggled(bool)), this, SLOT(onMousePublish(bool)));

--- a/rqt_image_view/src/rqt_image_view/image_view.ui
+++ b/rqt_image_view/src/rqt_image_view/image_view.ui
@@ -144,7 +144,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0">
+    <layout class="QHBoxLayout" name="image_layout" stretch="1,0">
      <property name="spacing">
       <number>0</number>
      </property>

--- a/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
+++ b/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
@@ -79,18 +79,20 @@ void RatioLayoutedFrame::resizeToFitAspectRatio()
   // reduce longer edge to aspect ration
   double width = outer_layout_->contentsRect().width() - 2;
   double height = outer_layout_->contentsRect().height() - 2;
-  if (width * aspect_ratio_.height() / height > aspect_ratio_.width())
+  const double layout_ar = width / height;
+  const double image_ar = double(aspect_ratio_.width()) / double(aspect_ratio_.height());
+  if (layout_ar > image_ar)
   {
     // too large width
-    width = height * aspect_ratio_.width() / aspect_ratio_.height();
-    rect.setWidth(int(width + 0.5));
+    width = height * image_ar;
   }
   else
   {
     // too large height
-    height = width * aspect_ratio_.height() / aspect_ratio_.width();
-    rect.setHeight(int(height + 0.5));
+    height = width / image_ar;
   }
+  rect.setWidth(int(width + 0.5));
+  rect.setHeight(int(height + 0.5));
 
   // resize taking the border line into account
   int border = lineWidth();

--- a/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
+++ b/rqt_image_view/src/rqt_image_view/ratio_layouted_frame.cpp
@@ -30,6 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ros/ros.h>
 #include <rqt_image_view/ratio_layouted_frame.h>
 
 #include <assert.h>
@@ -68,7 +69,6 @@ void RatioLayoutedFrame::setImage(const QImage& image)//, QMutex* image_mutex)
   qimage_mutex_.lock();
   qimage_ = image.copy();
   qimage_mutex_.unlock();
-  setAspectRatio(qimage_.width(), qimage_.height());
   emit delayed_update();
 }
 
@@ -77,8 +77,8 @@ void RatioLayoutedFrame::resizeToFitAspectRatio()
   QRect rect = contentsRect();
 
   // reduce longer edge to aspect ration
-  double width = double(rect.width());
-  double height = double(rect.height());
+  double width = outer_layout_->contentsRect().width() - 2;
+  double height = outer_layout_->contentsRect().height() - 2;
   if (width * aspect_ratio_.height() / height > aspect_ratio_.width())
   {
     // too large width
@@ -95,6 +95,11 @@ void RatioLayoutedFrame::resizeToFitAspectRatio()
   // resize taking the border line into account
   int border = lineWidth();
   resize(rect.width() + 2 * border, rect.height() + 2 * border);
+}
+
+void RatioLayoutedFrame::setOuterLayout(QHBoxLayout* outer_layout)
+{
+  outer_layout_ = outer_layout;
 }
 
 void RatioLayoutedFrame::setInnerFrameMinimumSize(const QSize& size)
@@ -136,6 +141,7 @@ void RatioLayoutedFrame::paintEvent(QPaintEvent* event)
   qimage_mutex_.lock();
   if (!qimage_.isNull())
   {
+    setAspectRatio(qimage_.width(), qimage_.height());
     resizeToFitAspectRatio();
     // TODO: check if full draw is really necessary
     //QPaintEvent* paint_event = dynamic_cast<QPaintEvent*>(event);


### PR DESCRIPTION
Now the image will fill the available space instead of shrinking within the size of the previous image if the aspect ratio changes.  This fixes half of #437 

In zoom1 mode the aspect ratio is still wrong when the aspect ratio changes, I'll take a look at that next.