### PR TITLE
[rqt_graph] Show bad nodes even if debug (quiet) is set

### DIFF
--- a/rqt_graph/resource/RosGraph.ui
+++ b/rqt_graph/resource/RosGraph.ui
@@ -212,6 +212,16 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QCheckBox" name="unreachable_check_box">
+           <property name="toolTip">
+            <string>Hide unreachable nodes</string>
+           </property>
+           <property name="text">
+            <string>Unreachable</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>

--- a/rqt_graph/src/rqt_graph/dotcode.py
+++ b/rqt_graph/src/rqt_graph/dotcode.py
@@ -220,23 +220,28 @@ class RosGraphDotcodeGenerator:
 
     def _add_node(self, node, rosgraphinst, dotcode_factory, dotgraph, quiet):
         if node in rosgraphinst.bad_nodes:
-            if quiet:
-                return ''
             bn = rosgraphinst.bad_nodes[node]
             if bn.type == rosgraph.impl.graph.BadNode.DEAD:
                 dotcode_factory.add_node_to_graph(dotgraph,
                                                   nodename=_conv(node),
                                                   nodelabel=node,
-                                                  shape="doublecircle",
-                                                  url=node,
-                                                  color="red")
+                                                  shape="ellipse",
+                                                  url=node + " (DEAD)",
+                                                  color="orange")
+            elif bn.type == rosgraph.impl.graph.BadNode.WONKY:
+                dotcode_factory.add_node_to_graph(dotgraph,
+                                                  nodename=_conv(node),
+                                                  nodelabel=node,
+                                                  shape="ellipse",
+                                                  url=node + " (WONKY)",
+                                                  color="yellow")
             else:
                 dotcode_factory.add_node_to_graph(dotgraph,
                                                   nodename=_conv(node),
                                                   nodelabel=node,
-                                                  shape="doublecircle",
-                                                  url=node,
-                                                  color="orange")
+                                                  shape="ellipse",
+                                                  url=node + " (UNKNOWN)",
+                                                  color="red")
         else:
             dotcode_factory.add_node_to_graph(dotgraph,
                                               nodename=_conv(node),

--- a/rqt_graph/src/rqt_graph/dotcode.py
+++ b/rqt_graph/src/rqt_graph/dotcode.py
@@ -218,8 +218,10 @@ class RosGraphDotcodeGenerator:
                 dotcode_factory.add_edge_to_graph(dotgraph, _conv(edge.start), _conv(edge.end), label=edge.label)
 
 
-    def _add_node(self, node, rosgraphinst, dotcode_factory, dotgraph, quiet):
+    def _add_node(self, node, rosgraphinst, dotcode_factory, dotgraph, unreachable):
         if node in rosgraphinst.bad_nodes:
+            if unreachable:
+                return ''
             bn = rosgraphinst.bad_nodes[node]
             if bn.type == rosgraph.impl.graph.BadNode.DEAD:
                 dotcode_factory.add_node_to_graph(dotgraph,
@@ -227,14 +229,14 @@ class RosGraphDotcodeGenerator:
                                                   nodelabel=node,
                                                   shape="ellipse",
                                                   url=node + " (DEAD)",
-                                                  color="orange")
+                                                  color="red")
             elif bn.type == rosgraph.impl.graph.BadNode.WONKY:
                 dotcode_factory.add_node_to_graph(dotgraph,
                                                   nodename=_conv(node),
                                                   nodelabel=node,
                                                   shape="ellipse",
                                                   url=node + " (WONKY)",
-                                                  color="yellow")
+                                                  color="orange")
             else:
                 dotcode_factory.add_node_to_graph(dotgraph,
                                                   nodename=_conv(node),
@@ -433,7 +435,8 @@ class RosGraphDotcodeGenerator:
                          ranksep=0.2,  # vertical distance between layers
                          rankdir='TB',  # direction of layout (TB top > bottom, LR left > right)
                          simplify=True,  # remove double edges
-                         quiet=False):
+                         quiet=False,
+                         unreachable=False):
         """
         See generate_dotcode
         """
@@ -518,9 +521,9 @@ class RosGraphDotcodeGenerator:
                     namespace = str(n).split('/')[1]
                     if namespace not in namespace_clusters:
                         namespace_clusters[namespace] = dotcode_factory.add_subgraph_to_graph(dotgraph, namespace, rank=rank, rankdir=orientation, simplify=simplify)
-                    self._add_node(n, rosgraphinst=rosgraphinst, dotcode_factory=dotcode_factory, dotgraph=namespace_clusters[namespace], quiet=quiet)
+                    self._add_node(n, rosgraphinst=rosgraphinst, dotcode_factory=dotcode_factory, dotgraph=namespace_clusters[namespace], unreachable=unreachable)
                 else:
-                    self._add_node(n, rosgraphinst=rosgraphinst, dotcode_factory=dotcode_factory, dotgraph=dotgraph, quiet=quiet)
+                    self._add_node(n, rosgraphinst=rosgraphinst, dotcode_factory=dotcode_factory, dotgraph=dotgraph, unreachable=unreachable)
 
         for e in edges:
             self._add_edge(e, dotcode_factory, dotgraph=dotgraph, is_topic=(graph_mode == NODE_NODE_GRAPH))
@@ -547,7 +550,8 @@ class RosGraphDotcodeGenerator:
                          ranksep=0.2,  # vertical distance between layers
                          rankdir='TB',  # direction of layout (TB top > bottom, LR left > right)
                          simplify=True,  # remove double edges
-                         quiet=False):
+                         quiet=False,
+                         unreachable=False):
         """
         @param rosgraphinst: RosGraph instance
         @param ns_filter: nodename filter
@@ -580,6 +584,7 @@ class RosGraphDotcodeGenerator:
                          ranksep=ranksep,
                          rankdir=rankdir,
                          simplify=simplify,
-                         quiet=quiet)
+                         quiet=quiet,
+                         unreachable=unreachable)
         dotcode = dotcode_factory.create_dot(dotgraph)
         return dotcode

--- a/rqt_graph/src/rqt_graph/ros_graph.py
+++ b/rqt_graph/src/rqt_graph/ros_graph.py
@@ -152,6 +152,7 @@ class RosGraph(Plugin):
         self._widget.dead_sinks_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.leaf_topics_check_box.clicked.connect(self._refresh_rosgraph)
         self._widget.quiet_check_box.clicked.connect(self._refresh_rosgraph)
+        self._widget.unreachable_check_box.clicked.connect(self._refresh_rosgraph)
 
         self._widget.refresh_graph_push_button.setIcon(QIcon.fromTheme('view-refresh'))
         self._widget.refresh_graph_push_button.pressed.connect(self._update_rosgraph)
@@ -185,6 +186,7 @@ class RosGraph(Plugin):
         instance_settings.set_value('dead_sinks_check_box_state', self._widget.dead_sinks_check_box.isChecked())
         instance_settings.set_value('leaf_topics_check_box_state', self._widget.leaf_topics_check_box.isChecked())
         instance_settings.set_value('quiet_check_box_state', self._widget.quiet_check_box.isChecked())
+        instance_settings.set_value('unreachable_check_box_state', self._widget.unreachable_check_box.isChecked())
         instance_settings.set_value('auto_fit_graph_check_box_state', self._widget.auto_fit_graph_check_box.isChecked())
         instance_settings.set_value('highlight_connections_check_box_state', self._widget.highlight_connections_check_box.isChecked())
 
@@ -197,6 +199,7 @@ class RosGraph(Plugin):
         self._widget.dead_sinks_check_box.setChecked(instance_settings.value('dead_sinks_check_box_state', True) in [True, 'true'])
         self._widget.leaf_topics_check_box.setChecked(instance_settings.value('leaf_topics_check_box_state', True) in [True, 'true'])
         self._widget.quiet_check_box.setChecked(instance_settings.value('quiet_check_box_state', True) in [True, 'true'])
+        self._widget.unreachable_check_box.setChecked(instance_settings.value('unreachable_check_box_state', True) in [True, 'true'])
         self._widget.auto_fit_graph_check_box.setChecked(instance_settings.value('auto_fit_graph_check_box_state', True) in [True, 'true'])
         self._widget.highlight_connections_check_box.setChecked(instance_settings.value('highlight_connections_check_box_state', True) in [True, 'true'])
         self.initialized = True
@@ -212,6 +215,7 @@ class RosGraph(Plugin):
         self._widget.dead_sinks_check_box.setEnabled(True)
         self._widget.leaf_topics_check_box.setEnabled(True)
         self._widget.quiet_check_box.setEnabled(True)
+        self._widget.unreachable_check_box.setEnabled(True)
 
         self._graph = rosgraph.impl.graph.Graph()
         self._graph.set_master_stale(5.0)
@@ -239,6 +243,7 @@ class RosGraph(Plugin):
         hide_dead_end_topics = self._widget.dead_sinks_check_box.isChecked()
         hide_single_connection_topics = self._widget.leaf_topics_check_box.isChecked()
         quiet = self._widget.quiet_check_box.isChecked()
+        unreachable = self._widget.unreachable_check_box.isChecked()
 
         return self.dotcode_generator.generate_dotcode(
             rosgraphinst=self._graph,
@@ -251,7 +256,8 @@ class RosGraph(Plugin):
             accumulate_actions=accumulate_actions,
             dotcode_factory=self.dotcode_factory,
             orientation=orientation,
-            quiet=quiet)
+            quiet=quiet,
+            unreachable=unreachable)
 
     def _update_graph_view(self, dotcode):
         if dotcode == self._current_dotcode:
@@ -324,6 +330,7 @@ class RosGraph(Plugin):
         self._widget.dead_sinks_check_box.setEnabled(False)
         self._widget.leaf_topics_check_box.setEnabled(False)
         self._widget.quiet_check_box.setEnabled(False)
+        self._widget.unreachable_check_box.setEnabled(False)
 
         self._update_graph_view(dotcode)
 


### PR DESCRIPTION
The description of debug is given as `Hide common debugging nodes`. Without this patch it also hides nodes that rqt_graph cannot connect to as they are marked as Bad Nodes.

This creates a problem when rqt_graph can only connect to the ROS master as all nodes are marked as bad nodes. Debug can be shown but then the graph is polluted with `/rosout` connections and the nodes are drawn as large red circles.

To fix this I have stopped quiet (debug) affecting bad nodes being shown and I have also  changed the nodes so they are shown as colored ellipses similar to working nodes.