### PR TITLE
Add rqt_bag to the rqt_common_plugins metapackage

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -33,8 +33,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>rqt_action</exec_depend>
-  <!-- <exec_depend>rqt_bag</exec_depend> -->
-  <!-- <exec_depend>rqt_bag_plugins</exec_depend> -->
+  <exec_depend>rqt_bag</exec_depend>
+  <exec_depend>rqt_bag_plugins</exec_depend>
   <exec_depend>rqt_console</exec_depend>
   <!-- <exec_depend>rqt_dep</exec_depend> -->
   <exec_depend>rqt_graph</exec_depend>


### PR DESCRIPTION
rqt_bag is now available for ROS2 in the Rolling release. 

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>