### PR TITLE
Remove unreleased plugins from rqt_common_plugins.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -36,11 +36,8 @@
   <exec_depend>rqt_bag</exec_depend>
   <exec_depend>rqt_bag_plugins</exec_depend>
   <exec_depend>rqt_console</exec_depend>
-  <!-- <exec_depend>rqt_dep</exec_depend> -->
   <exec_depend>rqt_graph</exec_depend>
   <exec_depend>rqt_image_view</exec_depend>
-  <!-- <exec_depend>rqt_launch</exec_depend> -->
-  <!-- <exec_depend>rqt_logger_level</exec_depend> -->
   <exec_depend>rqt_msg</exec_depend>
   <exec_depend>rqt_plot</exec_depend>
   <exec_depend>rqt_publisher</exec_depend>
@@ -50,9 +47,7 @@
   <exec_depend>rqt_service_caller</exec_depend>
   <exec_depend>rqt_shell</exec_depend>
   <exec_depend>rqt_srv</exec_depend>
-  <exec_depend>rqt_top</exec_depend>
   <exec_depend>rqt_topic</exec_depend>
-  <!-- <exec_depend>rqt_web</exec_depend> -->
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
These are ones that either don't work well, or have never
been ported to ROS 2.  We can always add them back if we
port them over.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>